### PR TITLE
Add Windows CI PYTHONPATH export step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
           python -m pip install --upgrade pip
           if (Test-Path requirements.txt) { pip install -r requirements.txt }
           pip install pillow
+      - name: Add repo to PYTHONPATH
+        run: Add-Content $env:GITHUB_ENV "PYTHONPATH=$(Get-Location)"
       - name: Compile sources
         run: python -m compileall pipeline_core video_processor.py run_pipeline.py
       - name: Run tests


### PR DESCRIPTION
## Summary
- add a Windows PowerShell step to export the repository path to `PYTHONPATH` before compilation and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `video_processor` and `pipeline_core` when PYTHONPATH is not set locally)*
- `PYTHONPATH=$PWD pytest -q` *(fails: ImportError for `cv2` due to missing `libGL.so.1` in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfda6ec3888330a11540178ef653c5