### PR TITLE
Update CI Python version to 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install deps
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- update the Windows CI job to install Python 3.11 via actions/setup-python

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cfdc4ad2b0833085fb32179b2c7254