### PR TITLE
Normalize fetch keywords when language is English

### DIFF
--- a/tests/test_llm_dynamic_context.py
+++ b/tests/test_llm_dynamic_context.py
@@ -46,3 +46,18 @@ def test_dynamic_context_fallback_keywords():
     result = service.generate_dynamic_context(transcript)
     assert result["keywords"], "fallback keywords missing"
     assert all(len(term) >= 3 for term in result["keywords"])
+
+
+def test_force_english_terms_when_language_en():
+    payload = json.dumps(
+        {
+            "language": "en",
+            "keywords": ["récompense", "durée"],
+            "search_queries": ["plan de récompense", "augmentation de durée"],
+        }
+    )
+    service = DummyService(payload)
+    result = service.generate_dynamic_context("Une transcription en anglais implicite")
+    assert "reward" in result["keywords"]
+    assert "duration" in result["keywords"]
+    assert all("récompense" not in q and "durée" not in q for q in result["search_queries"])

--- a/video_processor.py
+++ b/video_processor.py
@@ -238,7 +238,7 @@ from pipeline_core.configuration import PipelineConfigBundle
 from pipeline_core.fetchers import FetcherOrchestrator
 from pipeline_core.dedupe import compute_phash, hamming_distance
 from pipeline_core.logging import JsonlLogger, log_broll_decision
-from pipeline_core.llm_service import LLMMetadataGeneratorService
+from pipeline_core.llm_service import LLMMetadataGeneratorService, enforce_fetch_language
 
 # 🚀 NOUVEAU: Cache global pour éviter le rechargement des modèles
 _MODEL_CACHE = {}
@@ -2326,8 +2326,9 @@ class VideoProcessor:
                     transcript_tokens = []
                 pool = [t for t in transcript_tokens if isinstance(t, str) and len(t) >= 4][:10]
 
-            selector_keywords = _dedupe_queries(pool, cap=12)
-            fetch_keywords = _dedupe_queries(pool, cap=8)
+            language = dyn_context.get("language")
+            selector_keywords = enforce_fetch_language(_dedupe_queries(pool, cap=12), language)
+            fetch_keywords = enforce_fetch_language(_dedupe_queries(pool, cap=8), language)
 
             # Ensure bilingual queries when original language isn't English, if LLM provided EN
             try:


### PR DESCRIPTION
## Summary
- add an English equivalents map and an `enforce_fetch_language` helper to normalise LLM keywords/queries
- apply the helper in the LLM service and video processor to keep fetch terms consistent when language is English
- cover the behaviour with a regression test for French inputs returning English language metadata

## Testing
- pytest tests/test_llm_dynamic_context.py

------
https://chatgpt.com/codex/tasks/task_e_68d65cfd2d588330bd8a36de1f19b9e0