### PR TITLE
Normalize accented fetch terms to English equivalents

### DIFF
--- a/pipeline_core/llm_service.py
+++ b/pipeline_core/llm_service.py
@@ -96,13 +96,19 @@ _GENERIC_TERMS = {
 
 
 _EN_EQUIVALENTS = {
+    "adrnaline": "adrenaline",
+    "adrenaline": "adrenaline",
+    "adrenalin": "adrenaline",
+    "controle": "control",
+    "contrle": "control",
+    "processus": "process",
     "recompense": "reward",
     "recompenses": "rewards",
     "rcompense": "reward",
     "rcompenses": "rewards",
+    "dure": "duration",
     "duree": "duration",
     "durees": "durations",
-    "dure": "duration",
     "objectif": "goal",
     "objectifs": "goals",
     "reussite": "success",
@@ -174,10 +180,14 @@ def enforce_fetch_language(terms: Iterable[str], language: Optional[str]) -> Lis
             continue
         tokens: List[str] = []
         for token in raw.split():
-            base = _EN_EQUIVALENTS.get(token)
+            token_norm = token.lower()
+            base = _EN_EQUIVALENTS.get(token_norm)
             if base is None:
-                ascii_token = _strip_diacritics(token)
-                base = _EN_EQUIVALENTS.get(ascii_token, token)
+                ascii_token = _strip_diacritics(token_norm)
+                ascii_token = ascii_token.lower()
+                base = _EN_EQUIVALENTS.get(ascii_token)
+                if base is None:
+                    base = ascii_token or token
             tokens.append(base)
         candidate = " ".join(tok for tok in tokens if tok)
         if candidate and candidate not in seen:

--- a/tests/test_llm_dynamic_context.py
+++ b/tests/test_llm_dynamic_context.py
@@ -61,3 +61,17 @@ def test_force_english_terms_when_language_en():
     assert "reward" in result["keywords"]
     assert "duration" in result["keywords"]
     assert all("récompense" not in q and "durée" not in q for q in result["search_queries"])
+
+
+def test_force_english_terms_handles_accented_sequences():
+    payload = json.dumps(
+        {
+            "language": "en",
+            "keywords": ["adrénaline récompense contrôle"],
+            "search_queries": ["adrénaline récompense contrôle processus"],
+        }
+    )
+    service = DummyService(payload)
+    result = service.generate_dynamic_context("Adrénaline récompense contrôle")
+    assert result["keywords"] == ["adrenaline reward control"]
+    assert result["search_queries"] == ["adrenaline reward control process"]


### PR DESCRIPTION
## Summary
- expand the English equivalent mapping to include adrenaline/control/process variants and prefer accent-stripped tokens in the fallback path
- normalize fallback handling so accent-stripped values are used when no explicit mapping exists
- add coverage asserting accented French keywords and queries are converted to English terms

## Testing
- pytest tests/test_llm_dynamic_context.py

------
https://chatgpt.com/codex/tasks/task_e_68d7069f62c08330ad9ac8c0e5f7aa7f