### PR TITLE
Implement core B-roll rendering pipeline

### DIFF
--- a/tests/test_no_repeat_assets.py
+++ b/tests/test_no_repeat_assets.py
@@ -224,9 +224,13 @@ def test_fallback_selects_candidate_when_min_score_too_high():
 
     original_fetcher = vp.FetcherOrchestrator
     original_dedupe_by_phash = vp.dedupe_by_phash
+    original_download = vp.VideoProcessor._download_core_candidate
+    original_render = vp.VideoProcessor._render_core_broll_timeline
     try:
         vp.FetcherOrchestrator = lambda cfg: SimpleNamespace(fetch_candidates=fake_fetch_candidates)
         vp.dedupe_by_phash = lambda candidates: (candidates, 0)
+        vp.VideoProcessor._download_core_candidate = lambda self, *_args, **_kwargs: Path("core_asset.mp4")
+        vp.VideoProcessor._render_core_broll_timeline = lambda self, *_args, **_kwargs: Path("rendered.mp4")
 
         processor._insert_brolls_pipeline_core(
             segments=[SimpleNamespace(start=0.0, end=4.0, text="hello world")],
@@ -237,6 +241,8 @@ def test_fallback_selects_candidate_when_min_score_too_high():
     finally:
         vp.FetcherOrchestrator = original_fetcher
         vp.dedupe_by_phash = original_dedupe_by_phash
+        vp.VideoProcessor._download_core_candidate = original_download
+        vp.VideoProcessor._render_core_broll_timeline = original_render
 
     assert "https://cdn/fallback.mp4" in vp.SEEN_URLS
     assert "asset-1" in vp.SEEN_IDENTIFIERS


### PR DESCRIPTION
## Summary
- materialise selected core B-roll assets, build placement timelines, and render composite clips in `video_processor.py`
- ensure the pipeline core returns both insertion counts and rendered paths so the legacy pipeline only runs when necessary
- add integration coverage validating that the renderer is invoked and adjust existing tests to stub new download/render helpers

## Testing
- pytest tests/test_video_processor.py::test_core_pipeline_materializes_and_renders tests/test_no_repeat_assets.py::test_fallback_selects_candidate_when_min_score_too_high

------
https://chatgpt.com/codex/tasks/task_e_68d7c71245e483308ad2c7dc6c4a8b1d