### PR TITLE
Expose CLI banner for zero B-roll insertions

### DIFF
--- a/main.py
+++ b/main.py
@@ -501,8 +501,8 @@ def main():
 	
 	# Import tardif du pipeline pour éviter l'échec avant le check de dépendances
 	try:
-		global VideoProcessor, Config
-		from video_processor import VideoProcessor, Config
+                global VideoProcessor, Config, format_broll_completion_banner
+                from video_processor import VideoProcessor, Config, format_broll_completion_banner
 	except Exception as e:
 		if args.cli:
 			print(f"❌ Erreur d'import du pipeline: {e}")
@@ -572,7 +572,11 @@ def main():
 			# B-rolls avec les mots-clés LLM (CORRIGÉ)
 			broll_path = processor.insert_brolls_if_enabled(reframed_path, subtitles, broll_keywords)
 			broll_time = time.time() - broll_start
-			print(f"    ✅ B-roll insérés avec succès ({broll_time:.1f}s)", flush=True)
+			_, banner = format_broll_completion_banner(
+				processor.get_last_broll_insert_count(),
+				origin="pipeline_core",
+			)
+			print(banner, flush=True)
 			
 			print(f"✨ Étape 4/4: Ajout des sous-titres Hormozi 1...", flush=True)
 			subtitles_start = time.time()

--- a/tests/test_cli_banner.py
+++ b/tests/test_cli_banner.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+
+def test_cli_warns_when_no_broll_inserted(monkeypatch, tmp_path, capsys):
+    # Ensure optional runtime dependencies resolve during the CLI boot path.
+    monkeypatch.setitem(sys.modules, "whisper", types.SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "moviepy", types.SimpleNamespace())
+
+    def _fake_add_hormozi_subtitles(src: str, subtitles, dst: str) -> None:  # pragma: no cover - trivial stub
+        Path(dst).touch()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hormozi_subtitles",
+        types.SimpleNamespace(add_hormozi_subtitles=_fake_add_hormozi_subtitles),
+    )
+
+    import main as cli
+
+    output_root = tmp_path / "output"
+
+    class DummyConfig:
+        CLIPS_FOLDER = tmp_path / "clips"
+        OUTPUT_FOLDER = output_root
+        TEMP_FOLDER = tmp_path / "temp"
+
+    class DummyProcessor:
+        def __init__(self):
+            self._count = 0
+
+        def reframe_to_vertical(self, video_path):
+            return tmp_path / "reframed.mp4"
+
+        def transcribe_segments(self, clip_path):
+            return ["segment"]
+
+        def generate_caption_and_hashtags(self, subtitles):
+            return "title", "description", ["#tag"], ["kw1", "kw2"]
+
+        def insert_brolls_if_enabled(self, clip_path, subtitles, keywords):
+            return tmp_path / "with_broll.mp4"
+
+        def get_last_broll_insert_count(self):
+            return self._count
+
+    def _fake_banner(count, *, origin="pipeline"):
+        if int(count) > 0:
+            return True, f"    ✅ B-roll insérés avec succès ({int(count)})"
+        if origin == "pipeline_core":
+            return False, "    ⚠️ Pipeline core: aucun B-roll sélectionné; retour à la vidéo d'origine"
+        return False, "    ⚠️ Aucun B-roll inséré; retour à la vidéo d'origine"
+
+    monkeypatch.setitem(
+        sys.modules,
+        "video_processor",
+        types.SimpleNamespace(
+            VideoProcessor=DummyProcessor,
+            Config=DummyConfig,
+            format_broll_completion_banner=_fake_banner,
+        ),
+    )
+
+    video_path = tmp_path / "source.mp4"
+    video_path.write_bytes(b"test")
+
+    monkeypatch.setattr(sys, "argv", ["main.py", "--cli", "--video", str(video_path)])
+
+    cli.main()
+
+    captured = capsys.readouterr().out
+
+    assert "⚠️ Pipeline core: aucun B-roll sélectionné; retour à la vidéo d'origine" in captured
+    assert "B-roll insérés avec succès" not in captured

--- a/video_processor.py
+++ b/video_processor.py
@@ -906,7 +906,12 @@ class VideoProcessor:
         self._last_broll_insert_count = 0
         self._pipeline_config = PipelineConfigBundle()
         self._broll_event_logger = None
-    
+
+    def get_last_broll_insert_count(self) -> int:
+        """Return the number of B-roll clips inserted during the last run."""
+
+        return getattr(self, "_last_broll_insert_count", 0)
+
     def _setup_directories(self):
         """Crée les dossiers nécessaires"""
         for folder in [Config.CLIPS_FOLDER, Config.OUTPUT_FOLDER, Config.TEMP_FOLDER]:


### PR DESCRIPTION
## Summary
- add a lightweight accessor on `VideoProcessor` for the last B-roll insertion count
- route the CLI success message through `format_broll_completion_banner` so zero insertions print the warning banner
- cover the CLI branch with a regression test that fakes a zero-insertion processor and checks the warning output

## Testing
- pytest tests/test_cli_banner.py


------
https://chatgpt.com/codex/tasks/task_e_68d7ca3c45d08330b49fe046f1e47a52