### PR TITLE
Filter English stopwords from dynamic context terms

### DIFF
--- a/pipeline_core/llm_service.py
+++ b/pipeline_core/llm_service.py
@@ -95,6 +95,93 @@ _GENERIC_TERMS = {
 }
 
 
+_STOPWORDS_EN = {
+    'a',
+    'an',
+    'and',
+    'any',
+    'are',
+    'as',
+    'at',
+    'be',
+    'been',
+    'being',
+    'but',
+    'by',
+    'can',
+    'could',
+    'did',
+    'do',
+    'does',
+    'doing',
+    'for',
+    'from',
+    'had',
+    'has',
+    'have',
+    'having',
+    'he',
+    'her',
+    'hers',
+    'him',
+    'his',
+    'i',
+    'if',
+    'in',
+    'into',
+    'is',
+    'it',
+    'its',
+    'may',
+    'me',
+    'might',
+    'mine',
+    'must',
+    'my',
+    'of',
+    'on',
+    'or',
+    'our',
+    'ours',
+    'she',
+    'should',
+    'so',
+    'some',
+    'such',
+    'than',
+    'that',
+    'the',
+    'their',
+    'theirs',
+    'them',
+    'then',
+    'there',
+    'these',
+    'they',
+    'this',
+    'those',
+    'through',
+    'to',
+    'too',
+    'up',
+    'was',
+    'we',
+    'were',
+    'when',
+    'where',
+    'which',
+    'who',
+    'whom',
+    'why',
+    'will',
+    'with',
+    'would',
+    'you',
+    'your',
+    'yours',
+}
+
+
 _EN_EQUIVALENTS = {
     "adrnaline": "adrenaline",
     "adrenaline": "adrenaline",
@@ -144,17 +231,21 @@ def _normalise_terms(values: Iterable[str], *, limit: Optional[int] = None) -> L
         term = value.strip().lower().replace('_', ' ')
         term = re.sub(r"\s+", ' ', term)
         term = re.sub(r"[^a-z0-9\s-]", '', term)
-        if len(term) < _TERM_MIN_LEN:
-            continue
-        if term in _GENERIC_TERMS:
-            continue
         tokens = [t for t in term.split() if t]
-        if any(t in _GENERIC_TERMS for t in tokens):
+        filtered_tokens = [t for t in tokens if t not in _STOPWORDS_EN]
+        if not filtered_tokens:
             continue
-        if term in seen:
+        if any(t in _GENERIC_TERMS for t in filtered_tokens):
             continue
-        seen.add(term)
-        normalised.append(term)
+        cleaned = " ".join(filtered_tokens)
+        if len(cleaned) < _TERM_MIN_LEN:
+            continue
+        if cleaned in _GENERIC_TERMS:
+            continue
+        if cleaned in seen:
+            continue
+        seen.add(cleaned)
+        normalised.append(cleaned)
         if limit is not None and len(normalised) >= limit:
             break
     return normalised

--- a/tests/test_llm_dynamic_context.py
+++ b/tests/test_llm_dynamic_context.py
@@ -19,9 +19,13 @@ def test_dynamic_context_normalisation():
         {
             "detected_domains": [{"name": "Neuro_Science", "confidence": 0.87}],
             "language": "EN",
-            "keywords": ["DOPAMINE_boost", "focus", "focus"],
+            "keywords": [
+                "DOPAMINE_boost",
+                "focus and clarity",
+                "clarity when they concentrate",
+            ],
             "synonyms": {"DOPAMINE_boost": ["dopamine surge", "chemical boost"]},
-            "search_queries": ["brain focus shot", "nice people"],
+            "search_queries": ["brain focus when shot", "they and act"],
             "segment_briefs": [
                 {"segment_index": "0", "keywords": ["Neural_Pathway"], "queries": ["brain first"]}
             ],
@@ -30,10 +34,19 @@ def test_dynamic_context_normalisation():
     service = DummyService(payload)
     result = service.generate_dynamic_context("Dopamine keeps you motivated")
     assert result["detected_domains"][0]["name"] == "neuro science"
-    assert result["keywords"] == ["dopamine boost", "focus"]
-    assert result["search_queries"] == ["brain focus shot"]
+    assert result["keywords"] == [
+        "dopamine boost",
+        "focus clarity",
+        "clarity concentrate",
+    ]
+    assert result["search_queries"] == ["brain focus shot", "act"]
     assert result["segment_briefs"][0]["keywords"] == ["neural pathway"]
     assert result["segment_briefs"][0]["queries"] == []
+    for term in result["keywords"] + result["search_queries"]:
+        tokens = term.split()
+        assert "and" not in tokens
+        assert "when" not in tokens
+        assert "they" not in tokens
 
 
 def test_dynamic_context_fallback_keywords():


### PR DESCRIPTION
## Summary
- add an English stopword list to term normalisation so filler tokens are removed from keywords and queries
- rejoin multi-word phrases after stopword filtering and skip phrases that collapse to nothing
- extend dynamic context tests to confirm stopwords such as "and", "when", and "they" are excluded from keywords and provider queries

## Testing
- pytest tests/test_llm_dynamic_context.py

------
https://chatgpt.com/codex/tasks/task_e_68d7ceeb78c88330ab8a82d9289b4ee4