### PR TITLE
Persist core b-roll timeline assets and tighten CLI coverage

### DIFF
--- a/tests/test_video_processor.py
+++ b/tests/test_video_processor.py
@@ -309,7 +309,7 @@ def test_core_pipeline_materializes_and_renders(monkeypatch, tmp_path, video_pro
         return downloaded_asset
 
     def fake_render(self, base_path, timeline):
-        captured_timeline["timeline"] = timeline
+        captured_timeline["timeline"] = list(timeline)
         rendered_path = temp_dir / "core" / "rendered.mp4"
         rendered_path.parent.mkdir(parents=True, exist_ok=True)
         rendered_path.write_bytes(b"render")
@@ -332,7 +332,11 @@ def test_core_pipeline_materializes_and_renders(monkeypatch, tmp_path, video_pro
     assert rendered_path is not None
     assert rendered_path != input_clip
     assert captured_timeline.get("timeline")
-    assert captured_timeline["timeline"][0]["path"] == downloaded_asset
+    first_entry = captured_timeline["timeline"][0]
+    assert isinstance(first_entry, module.CoreTimelineEntry)
+    assert first_entry.path == downloaded_asset
+    assert pytest.approx(first_entry.start, rel=1e-6) == 0.0
+    assert pytest.approx(first_entry.end, rel=1e-6) == 1.5
 
     sys.modules.pop("video_processor", None)
 


### PR DESCRIPTION
## Summary
- add a `CoreTimelineEntry` model so the core pipeline saves its downloaded clips and segment windows, including a manifest on disk and cached state for debugging
- attempt to render the core timeline through the existing `src.pipeline.renderer.render_video` helper with a moviepy fallback when unavailable
- extend the processor and CLI tests to assert the dataclass timeline is produced and that successful insertions update the CLI banner and subtitle source path

## Testing
- pytest tests/test_video_processor.py tests/test_cli_banner.py tests/test_summary_event.py

------
https://chatgpt.com/codex/tasks/task_e_68d7f45f8e5c833082e24b3e1c03b7d8