### PR TITLE
Improve timeout handling in metadata service

### DIFF
--- a/tests/test_llm_dynamic_context.py
+++ b/tests/test_llm_dynamic_context.py
@@ -10,7 +10,7 @@ class DummyService(LLMMetadataGeneratorService):
         super().__init__(reuse_shared=False)
         self._payload = payload
 
-    def _complete_text(self, prompt: str) -> str:  # type: ignore[override]
+    def _complete_text(self, prompt: str, *, max_tokens: int = 800) -> str:  # type: ignore[override]
         return self._payload
 
 
@@ -51,7 +51,7 @@ def test_dynamic_context_normalisation():
 
 def test_dynamic_context_fallback_keywords():
     class Failing(LLMMetadataGeneratorService):
-        def _complete_text(self, prompt: str) -> str:  # type: ignore[override]
+        def _complete_text(self, prompt: str, *, max_tokens: int = 800) -> str:  # type: ignore[override]
             raise RuntimeError("boom")
 
     service = Failing(reuse_shared=False)


### PR DESCRIPTION
## Summary
- add configurable timeout for the shared LLM metadata service
- avoid retrying multiple completion methods after a timeout and reuse low-level helper
- provide helper utilities to pass timeout hints to integrations and detect timeout errors

## Testing
- python -m compileall pipeline_core/llm_service.py

------
https://chatgpt.com/codex/tasks/task_e_68d8206238248330bc89a507ae415ea5