### PR TITLE
Refine b-roll candidate telemetry and filtering order

### DIFF
--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -1,0 +1,36 @@
+from pipeline_core.configuration import FetcherOrchestratorConfig, ProviderConfig
+from pipeline_core.fetchers import FetcherOrchestrator, RemoteAssetCandidate
+
+
+def test_fetch_candidates_returns_unfiltered_results(monkeypatch):
+    config = FetcherOrchestratorConfig(
+        providers=(ProviderConfig(name="dummy", enabled=True, max_results=3),)
+    )
+    orchestrator = FetcherOrchestrator(config)
+
+    candidate = RemoteAssetCandidate(
+        provider="dummy",
+        url="http://example.com/video.mp4",
+        thumb_url=None,
+        width=720,
+        height=1280,
+        duration=2.0,
+        title="demo",
+        identifier="vid-1",
+        tags=(),
+    )
+
+    monkeypatch.setattr(
+        FetcherOrchestrator,
+        "_build_queries",
+        lambda self, keywords: ["demo"],
+    )
+    monkeypatch.setattr(
+        FetcherOrchestrator,
+        "_run_provider_fetch",
+        lambda self, provider_conf, query, filters, segment_timeout: [candidate],
+    )
+
+    results = orchestrator.fetch_candidates(["demo"], filters={"orientation": "landscape"})
+
+    assert results == [candidate]

--- a/tests/test_segment_queries.py
+++ b/tests/test_segment_queries.py
@@ -80,6 +80,9 @@ class DummyOrchestrator:
         self.fetch_calls.append((list(queries), duration_hint, dict(filters or {})))
         return []
 
+    def evaluate_candidate_filters(self, *_args, **_kwargs):
+        return True, None
+
 
 @pytest.mark.parametrize(
     "brief_terms,expected_phrases",

--- a/tests/test_video_processor.py
+++ b/tests/test_video_processor.py
@@ -37,6 +37,9 @@ def video_processor_module(monkeypatch):
         def fetch_candidates(self, *args, **kwargs):
             return []
 
+        def evaluate_candidate_filters(self, *_args, **_kwargs):
+            return True, None
+
     setattr(dummy_fetchers, "FetcherOrchestrator", DummyFetcherOrchestrator)
     monkeypatch.setitem(sys.modules, "pipeline_core.fetchers", dummy_fetchers)
 
@@ -401,6 +404,9 @@ def test_core_pipeline_materializes_and_renders(monkeypatch, tmp_path, video_pro
 
         def fetch_candidates(self, *_args, **_kwargs):
             return [candidate]
+
+        def evaluate_candidate_filters(self, *_args, **_kwargs):
+            return True, None
 
     monkeypatch.setattr(module, "FetcherOrchestrator", StubOrchestrator)
 


### PR DESCRIPTION
## Summary
- collect raw fetcher results and expose filter evaluation so orientation/duration checks happen during selection
- log per-candidate evaluation details, surface rejection counts in b-roll decision events, and tolerate in-memory logging during tests
- expand and adjust tests to cover the new telemetry payloads and fetcher behaviour

## Testing
- pytest tests/test_fetchers.py tests/test_summary_event.py
- pytest tests/test_no_repeat_assets.py tests/test_video_processor.py


------
https://chatgpt.com/codex/tasks/task_e_68d86d2e632483308249b001b4cb10b4