### PR TITLE
Add render_ok tracking and extend summary telemetry

### DIFF
--- a/tests/test_video_processor.py
+++ b/tests/test_video_processor.py
@@ -442,7 +442,7 @@ def test_core_pipeline_materializes_and_renders(monkeypatch, tmp_path, video_pro
     input_clip = tmp_path / "input.mp4"
     input_clip.write_bytes(b"base")
 
-    inserted_count, rendered_path = processor._insert_brolls_pipeline_core(
+    inserted_count, rendered_path, meta = processor._insert_brolls_pipeline_core(
         [types.SimpleNamespace(start=0.0, end=2.0, text="hello world")],
         ["sample"],
         subtitles=[],
@@ -452,6 +452,7 @@ def test_core_pipeline_materializes_and_renders(monkeypatch, tmp_path, video_pro
     assert inserted_count == 1
     assert rendered_path is not None
     assert rendered_path != input_clip
+    assert meta.get("render_ok") is True
     assert captured_timeline.get("timeline")
     first_entry = captured_timeline["timeline"][0]
     assert isinstance(first_entry, module.CoreTimelineEntry)


### PR DESCRIPTION
## Summary
- compute render_ok based on the rendered file and overlay assets, extending the summary payload with providers_used and dedupe_counts
- propagate the render_ok flag through banner generation and pipeline fallbacks so missing overlays fall back to the source clip
- update summary-related tests to assert the new telemetry fields and render_ok transitions during forced-keep scenarios

## Testing
- pytest tests/test_summary_event.py tests/test_video_processor.py tests/test_keep_best.py

------
https://chatgpt.com/codex/tasks/task_e_68d873311fb483308ef0f3d8890005d3