### PR TITLE
feat: load fetcher config overrides from environment

### DIFF
--- a/tests/test_fetcher_env_overrides.py
+++ b/tests/test_fetcher_env_overrides.py
@@ -1,0 +1,89 @@
+import pytest
+
+from pipeline_core.configuration import FetcherOrchestratorConfig
+from pipeline_core.fetchers import FetcherOrchestrator, RemoteAssetCandidate
+
+
+@pytest.fixture(autouse=True)
+def _restore_env(monkeypatch):
+    # Ensure provider API keys exist so orchestrator does not skip providers.
+    monkeypatch.setenv("PEXELS_API_KEY", "test-key")
+    monkeypatch.setenv("PIXABAY_API_KEY", "test-key")
+    yield
+
+
+def test_config_reads_environment_defaults(monkeypatch):
+    monkeypatch.setenv("FETCH_MAX", "4")
+    monkeypatch.setenv("BROLL_FETCH_PROVIDER", "pixabay")
+    monkeypatch.setenv("BROLL_FETCH_ALLOW_IMAGES", "1")
+    monkeypatch.setenv("BROLL_FETCH_ALLOW_VIDEOS", "0")
+
+    config = FetcherOrchestratorConfig.from_environment()
+
+    enabled = [provider for provider in config.providers if provider.enabled]
+    assert [provider.name for provider in enabled] == ["pixabay"]
+    assert all(provider.max_results == 4 for provider in enabled)
+    assert config.per_segment_limit == 4
+    assert config.allow_images is True
+    assert config.allow_videos is False
+
+
+def test_fetcher_respects_allow_flags(monkeypatch):
+    monkeypatch.setenv("BROLL_FETCH_MAX_PER_KEYWORD", "3")
+    monkeypatch.setenv("BROLL_FETCH_PROVIDER", "pexels")
+    monkeypatch.setenv("BROLL_FETCH_ALLOW_VIDEOS", "0")
+
+    config = FetcherOrchestratorConfig.from_environment()
+    orchestrator = FetcherOrchestrator(config)
+
+    calls = []
+
+    def _boom(self, *_args, **_kwargs):
+        calls.append(True)
+        return [RemoteAssetCandidate(
+            provider="pexels",
+            url="http://example.com/video.mp4",
+            thumb_url=None,
+            width=720,
+            height=1280,
+            duration=2.0,
+            title="demo",
+            identifier="vid-1",
+            tags=(),
+        )]
+
+    monkeypatch.setattr(FetcherOrchestrator, "_run_provider_fetch", _boom)
+    monkeypatch.setattr(FetcherOrchestrator, "_build_queries", lambda self, keywords: ["demo"])
+
+    assert orchestrator.fetch_candidates(["demo"]) == []
+    assert calls == []
+
+
+def test_fetcher_applies_segment_limit(monkeypatch):
+    monkeypatch.setenv("BROLL_FETCH_MAX_PER_KEYWORD", "2")
+    monkeypatch.setenv("BROLL_FETCH_PROVIDER", "pexels")
+    monkeypatch.setenv("BROLL_FETCH_ALLOW_VIDEOS", "1")
+
+    config = FetcherOrchestratorConfig.from_environment()
+    orchestrator = FetcherOrchestrator(config)
+
+    candidate = RemoteAssetCandidate(
+        provider="pexels",
+        url="http://example.com/video.mp4",
+        thumb_url=None,
+        width=720,
+        height=1280,
+        duration=2.0,
+        title="demo",
+        identifier="vid-",
+        tags=(),
+    )
+
+    def _capped(self, *_args, **_kwargs):
+        return [candidate, candidate, candidate]
+
+    monkeypatch.setattr(FetcherOrchestrator, "_run_provider_fetch", _capped)
+    monkeypatch.setattr(FetcherOrchestrator, "_build_queries", lambda self, keywords: ["demo"])
+
+    results = orchestrator.fetch_candidates(["demo"])
+    assert len(results) == 2


### PR DESCRIPTION
## Summary
- load per-segment limits, provider flags, and media toggles for the fetcher orchestrator from environment variables when building defaults
- propagate the computed limits to provider configurations and gate provider execution based on allow_images/allow_videos
- add unit coverage ensuring the orchestrator reacts to environment overrides

## Testing
- pytest tests/test_fetcher_env_overrides.py tests/test_fetchers.py
- pytest tests/test_provider_guard.py tests/test_fetcher_guardrails.py

------
https://chatgpt.com/codex/tasks/task_e_68d948e397a88330b3af81e4854ed90e