### PR TITLE
Ensure cv2 stubs provide module spec in tests

### DIFF
--- a/tests/test_segment_queries.py
+++ b/tests/test_segment_queries.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace, MethodType, ModuleType
 
+import importlib
+
 import json
 import os
 import re
@@ -22,6 +24,7 @@ if "cv2" not in sys.modules:
         CHAIN_APPROX_SIMPLE=0,
         INTER_LANCZOS4=0,
     )
+    sys.modules["cv2"].__spec__ = importlib.machinery.ModuleSpec("cv2", loader=None)
 
 if "src.pipeline.fetchers" not in sys.modules:
     fetchers_stub = ModuleType("src.pipeline.fetchers")

--- a/tests/test_segment_terms.py
+++ b/tests/test_segment_terms.py
@@ -1,3 +1,4 @@
+import importlib
 import sys
 import types
 
@@ -12,6 +13,7 @@ def _stub_module(name: str, **attrs):
 
 if "cv2" not in sys.modules:
     sys.modules["cv2"] = types.SimpleNamespace()
+    sys.modules["cv2"].__spec__ = importlib.machinery.ModuleSpec("cv2", loader=None)
 
 if "moviepy.editor" not in sys.modules:
     moviepy_editor = _stub_module(


### PR DESCRIPTION
## Summary
- add importlib machinery ModuleSpec assignment to the cv2 stub in test_segment_queries
- apply the same cv2 spec assignment to the segment terms test stub for consistency

## Testing
- PYENV_VERSION=3.13.3 python -m pytest tests/test_segment_queries.py tests/test_segment_terms.py *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68d94c7994f083309b990f06f2e852f0