### PR TITLE
Handle empty Ollama metadata responses gracefully

### DIFF
--- a/video_processor.py
+++ b/video_processor.py
@@ -3943,6 +3943,10 @@ class VideoProcessor:
                 video_id=f"video_{int(time.time())}"
             )
 
+            if not metadata_result:
+                print("    ⚠️ [LLM INDUSTRIEL] Réponse JSON vide ou non analysable")
+                raise ValueError("Réponse JSON vide ou non analysable")
+
             title = (metadata_result.get('title') or '').strip()
             description = (metadata_result.get('description') or '').strip()
             hashtags = [h for h in (metadata_result.get('hashtags') or []) if h]


### PR DESCRIPTION
## Summary
- add a balanced JSON extraction helper so string responses can be parsed before validation
- return `None` and log the raw Ollama payload when metadata parsing fails instead of raising immediately
- guard the video processor against empty metadata payloads so the fallback path can be triggered cleanly

## Testing
- python -m compileall pipeline_core/llm_service.py video_processor.py

------
https://chatgpt.com/codex/tasks/task_e_68d9ace99f54833093a7199f0e94f300