### PR TITLE
Log per-provider candidate events and align diag telemetry

### DIFF
--- a/tests/test_segment_queries.py
+++ b/tests/test_segment_queries.py
@@ -89,8 +89,8 @@ class DummyOrchestrator:
             instances = DummyOrchestrator.instances
         instances.append(self)
 
-    def fetch_candidates(self, queries, *, duration_hint, filters):  # noqa: D401 - simple stub
-        self.fetch_calls.append((list(queries), duration_hint, dict(filters or {})))
+    def fetch_candidates(self, queries, *, segment_index=None, duration_hint, filters):  # noqa: D401 - simple stub
+        self.fetch_calls.append((list(queries), segment_index, duration_hint, dict(filters or {})))
         return []
 
     def evaluate_candidate_filters(self, *_args, **_kwargs):
@@ -231,7 +231,8 @@ def test_selector_and_seed_queries_used_when_llm_empty(monkeypatch, tmp_path):
     assert DummyOrchestrator.instances, "expected orchestrator to be constructed"
     fetch_calls = DummyOrchestrator.instances[0].fetch_calls
     assert fetch_calls, "expected orchestrator fetch to be invoked"
-    queries_used, _, _ = fetch_calls[0]
+    queries_used, seg_idx, *_ = fetch_calls[0]
+    assert seg_idx == 0
     assert queries_used, "expected non-empty queries"
 
     logged_queries = [
@@ -287,7 +288,8 @@ def test_llm_hint_queries_bypass_merge(monkeypatch):
     assert DummyOrchestrator.instances, "expected orchestrator to be constructed"
     fetch_calls = DummyOrchestrator.instances[0].fetch_calls
     assert fetch_calls, "expected orchestrator fetch to be invoked"
-    queries_used, _, _ = fetch_calls[0]
+    queries_used, seg_idx, *_ = fetch_calls[0]
+    assert seg_idx == 0
     expected_queries = video_processor._dedupe_queries(
         ["Cinematic Skyline", "Happy Team Meeting"],
         cap=video_processor.SEGMENT_REFINEMENT_MAX_TERMS,

--- a/video_processor.py
+++ b/video_processor.py
@@ -1895,6 +1895,7 @@ class VideoProcessor:
             def _do_fetch():
                 return orchestrator.fetch_candidates(
                     queries,
+                    segment_index=idx,
                     duration_hint=seg_duration,
                     filters=filters,
                 )

--- a/video_processor_current_backup.py
+++ b/video_processor_current_backup.py
@@ -2731,9 +2731,8 @@ class VideoProcessor:
                 return orchestrator.fetch_candidates(
 
                     queries,
-
+                    segment_index=idx,
                     duration_hint=seg_duration,
-
                     filters=filters,
 
                     segment_timeout_s=eff_timeout,


### PR DESCRIPTION
## Summary
- emit a `broll_candidate_evaluated` event for each provider after candidate processing with the segment index
- pass the segment index from the video processor and update the diagnostic CLI to reuse the JSONL logger/orchestrator telemetry
- adjust tests and helpers for the new fetch signature

## Testing
- pytest tests/test_fetchers.py tests/test_segment_queries.py

------
https://chatgpt.com/codex/tasks/task_e_68dac2d398648330aa68367e1c0f850b