### PR TITLE
Log LLM hint usage and prioritise hint queries

### DIFF
--- a/video_processor.py
+++ b/video_processor.py
@@ -1770,12 +1770,23 @@ class VideoProcessor:
                 raw_hint_source = llm_hints.get('source') if isinstance(llm_hints, dict) else None
                 if isinstance(raw_hint_source, str) and raw_hint_source.strip():
                     hint_source = raw_hint_source.strip()
+                if hint_payload:
+                    try:
+                        logger.info(
+                            "[BROLL][LLM] segment=%.2f-%.2f queries=%s (source=%s)",
+                            float(getattr(segment, 'start', 0.0) or 0.0),
+                            float(getattr(segment, 'end', 0.0) or 0.0),
+                            hint_payload,
+                            hint_source or 'llm_hint',
+                        )
+                    except Exception:
+                        pass
 
             hint_terms: List[str] = []
             if hint_payload:
                 hint_terms = _dedupe_queries(hint_payload, cap=metadata_query_cap)
                 if hint_terms and not hint_source:
-                    hint_source = llm_source_label
+                    hint_source = 'llm_hint'
             if not hint_source:
                 hint_source = llm_source_label
 


### PR DESCRIPTION
## Summary
- log B-roll hint queries with the provided source metadata as soon as they arrive
- keep hint-driven fetches isolated so fallback paths only trigger when no hints exist

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dadbd885fc8330a43f5f51984f2a77