### PR TITLE
Improve fetcher configuration and LLM fallback handling

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 try:
     from dotenv import load_dotenv
     load_dotenv(override=True)
-except ImportError:  # pragma: no cover - keep working if optional dependency missing
+except Exception:  # pragma: no cover - keep working if optional dependency missing
     def load_dotenv(*_args, **_kwargs):
         return False
 
@@ -360,16 +360,19 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     if args.print_config:
         config = FetcherOrchestratorConfig.from_environment()
-        snapshot = _fetcher_config_snapshot(config)
-        pexels_key_present = bool(os.environ.get('PEXELS_API_KEY'))
-        print(
-            "[CONFIG] providers="
-            f"{snapshot['providers_env_raw'] or 'default'} | resolved_providers={snapshot['resolved_display']} | "
-            f"allow_images={str(snapshot['allow_images']).lower()} | "
-            f"allow_videos={str(snapshot['allow_videos']).lower()} | "
-            f"per_segment_limit={snapshot['per_segment_limit']} | "
-            f"pexels_key_present={str(pexels_key_present).lower()}"
+        providers_env_raw = os.getenv('BROLL_FETCH_PROVIDER') or os.getenv('AI_BROLL_FETCH_PROVIDER') or ''
+        resolved = resolved_providers(config)
+        resolved_display = ','.join(resolved) if resolved else 'pixabay'
+        pexels_key_present = bool(os.getenv('PEXELS_API_KEY'))
+        line = (
+            f"providers={providers_env_raw or 'default'} | "
+            f"resolved_providers={resolved_display} | "
+            f"allow_images={str(bool(config.allow_images)).lower()} | "
+            f"allow_videos={str(bool(config.allow_videos)).lower()} | "
+            f"per_segment_limit={int(config.per_segment_limit)} | "
+            f"pexels_key_present={str(pexels_key_present)}"
         )
+        print(line)
         return 0
 
     if args.diag_broll:

--- a/video_processor.py
+++ b/video_processor.py
@@ -1770,23 +1770,28 @@ class VideoProcessor:
                 raw_hint_source = llm_hints.get('source') if isinstance(llm_hints, dict) else None
                 if isinstance(raw_hint_source, str) and raw_hint_source.strip():
                     hint_source = raw_hint_source.strip()
-                if hint_payload:
-                    try:
-                        logger.info(
-                            "[BROLL][LLM] segment=%.2f-%.2f queries=%s (source=%s)",
-                            float(getattr(segment, 'start', 0.0) or 0.0),
-                            float(getattr(segment, 'end', 0.0) or 0.0),
-                            hint_payload,
-                            hint_source or 'llm_hint',
-                        )
-                    except Exception:
-                        pass
 
             hint_terms: List[str] = []
             if hint_payload:
                 hint_terms = _dedupe_queries(hint_payload, cap=metadata_query_cap)
                 if hint_terms and not hint_source:
                     hint_source = 'llm_hint'
+                if hint_terms:
+                    logger.info(
+                        "[BROLL][LLM] segment=%.2f-%.2f queries=%s (source=%s)",
+                        float(getattr(segment, 'start', 0.0) or 0.0),
+                        float(getattr(segment, 'end', 0.0) or 0.0),
+                        hint_terms,
+                        hint_source or 'llm_hint',
+                    )
+                elif hint_payload:
+                    logger.info(
+                        "[BROLL][LLM] segment=%.2f-%.2f queries=%s (source=%s)",
+                        float(getattr(segment, 'start', 0.0) or 0.0),
+                        float(getattr(segment, 'end', 0.0) or 0.0),
+                        hint_payload,
+                        hint_source or 'llm_hint',
+                    )
             if not hint_source:
                 hint_source = llm_source_label
 
@@ -1815,10 +1820,6 @@ class VideoProcessor:
             if hint_terms:
                 queries = hint_terms
                 query_source = hint_source or 'llm_hint'
-                try:
-                    print(f"[BROLL][LLM] segment={idx} (source={query_source})")
-                except Exception:
-                    pass
                 if dyn_language in ('', 'en'):
                     queries = enforce_fetch_language(queries, dyn_language or None)
             else:
@@ -2267,7 +2268,7 @@ class VideoProcessor:
                     segment_idx = int(asset.get('segment', order))
                 except Exception:
                     segment_idx = order
-                local_path = self._download_core_candidate(candidate, download_dir, order, segment_idx)
+                local_path = self._download_core_candidate(candidate, download_dir, order)
                 if not local_path:
                     try:
                         event_logger.log({


### PR DESCRIPTION
## Summary
- unify environment parsing helpers and ensure provider lists fall back to pixabay with deterministic limits and resolved names
- harden the fetch orchestrator with pixabay fallbacks, JSONL telemetry, and deterministic LLM hint fallbacks logged through the video processor
- add coverage for env parsing and print-config plus adjust CLI diagnostics to surface resolved configuration data

## Testing
- pytest -q
- python run_pipeline.py --print-config
- python run_pipeline.py --diag-broll --no-report
- python run_pipeline.py --video "clips/121.mp4" --verbose

------
https://chatgpt.com/codex/tasks/task_e_68dad16b8c108330ae5d9f4d5bc1f106