### PR TITLE
Limit dotenv loading to CLI entrypoint

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 try:
     from dotenv import load_dotenv
-    load_dotenv(override=True)
 except Exception:  # pragma: no cover - keep working if optional dependency missing
     def load_dotenv(*_args, **_kwargs):
         return False


### PR DESCRIPTION
## Summary
- stop loading dotenv at import time in `run_pipeline` and keep CLI-scoped loading order
- ensure `.env` precedence is respected when invoking the CLI
- add regression test verifying importing `run_pipeline` does not trigger dotenv loading

## Testing
- pytest tests/test_run_pipeline_env.py

------
https://chatgpt.com/codex/tasks/task_e_68db0752285883308785879a432346bc