### PR TITLE
Format fetcher config reporting and add CLI diagnostics tests

### DIFF
--- a/tests/test_env_and_providers.py
+++ b/tests/test_env_and_providers.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -39,10 +40,11 @@ def test_resolved_providers_defaults_to_pixabay(monkeypatch):
     assert providers == ["pixabay"]
 
 
-def test_print_config_reports_pexels_key(monkeypatch):
+def test_print_config_reports_limits(monkeypatch):
     monkeypatch.setenv("PIXABAY_API_KEY", "dummy-key")
-    monkeypatch.setenv("PEXELS_API_KEY", "dummy-pexels")
+    monkeypatch.delenv("PEXELS_API_KEY", raising=False)
     monkeypatch.setenv("FETCH_MAX", "5")
+    monkeypatch.setenv("BROLL_FETCH_ALLOW_IMAGES", "0")
     monkeypatch.delenv("BROLL_FETCH_PROVIDER", raising=False)
     monkeypatch.delenv("AI_BROLL_FETCH_PROVIDER", raising=False)
 
@@ -53,7 +55,53 @@ def test_print_config_reports_pexels_key(monkeypatch):
         [sys.executable, "run_pipeline.py", "--print-config"],
         cwd=os.getcwd(),
         env=env,
-    ).decode("utf-8").strip()
+    ).decode("utf-8").strip().splitlines()
 
-    assert "pexels_key_present=" in output
-    assert "resolved_providers=" in output
+    assert output[0] == "providers=default"
+    assert output[1] == "resolved_providers=pixabay"
+    assert output[2] == "allow_images=false"
+    assert output[3] == "allow_videos=true"
+    assert output[4] == "per_segment_limit=5"
+    assert "provider=pixabay max_results=5" in output
+
+
+def test_diag_broll_reports_provider_limits(monkeypatch):
+    monkeypatch.setenv("PIXABAY_API_KEY", "dummy-key")
+    monkeypatch.delenv("PEXELS_API_KEY", raising=False)
+    monkeypatch.setenv("FETCH_MAX", "4")
+    monkeypatch.setenv("BROLL_FETCH_ALLOW_IMAGES", "0")
+    monkeypatch.delenv("BROLL_FETCH_PROVIDER", raising=False)
+    monkeypatch.delenv("AI_BROLL_FETCH_PROVIDER", raising=False)
+
+    env = os.environ.copy()
+    env.setdefault("PYTHONPATH", os.getcwd())
+
+    proc = subprocess.run(
+        [sys.executable, "run_pipeline.py", "--diag-broll"],
+        cwd=os.getcwd(),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    output = proc.stdout.decode("utf-8")
+    assert "[DIAG] providers=default" in output
+    assert "[DIAG] resolved_providers=pixabay" in output
+    assert "[DIAG] per_segment_limit=4" in output
+    assert "[DIAG] provider=pixabay max_results=4" in output
+
+    report_path = Path("diagnostic_broll.json")
+    if report_path.exists():
+        report_path.unlink()
+    events_path = Path("output/meta/broll_pipeline_events.jsonl")
+    if events_path.exists():
+        events_path.unlink()
+        try:
+            events_path.parent.rmdir()
+        except OSError:
+            pass
+        try:
+            events_path.parent.parent.rmdir()
+        except OSError:
+            pass


### PR DESCRIPTION
## Summary
- add a shared formatter for fetcher configuration output used by --print-config and the diagnostic helper
- ensure the diagnostic command prints effective provider limits before running the orchestrator
- update CLI tests to cover the new output layout and provider limit reporting

## Testing
- pytest tests/test_env_and_providers.py

------
https://chatgpt.com/codex/tasks/task_e_68db0826cf248330a07a4d33ccacd4ab