### PR TITLE
Defer dependency warnings until processor initialization

### DIFF
--- a/tests/test_env_and_providers.py
+++ b/tests/test_env_and_providers.py
@@ -86,7 +86,10 @@ def test_diag_broll_reports_provider_limits(monkeypatch):
     )
 
     output = proc.stdout.decode("utf-8")
-    assert "[DIAG] providers=default" in output
+    lines = [line for line in output.splitlines() if line.strip()]
+
+    assert lines, "expected diagnostic output"
+    assert lines[0] == "[DIAG] providers=default"
     assert "[DIAG] resolved_providers=pixabay" in output
     assert "[DIAG] per_segment_limit=4" in output
     assert "[DIAG] provider=pixabay max_results=4" in output


### PR DESCRIPTION
## Summary
- buffer dependency status messages in `video_processor` so CLI utilities run without import-time noise
- emit the buffered dependency messages when `VideoProcessor` initializes to preserve operator visibility
- assert the diagnostic CLI reports start with the providers header in the existing test

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db0b7969988330aa92bb936817b699