### PR TITLE
Improve provider capability filtering

### DIFF
--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pipeline_core.configuration import FetcherOrchestratorConfig, ProviderConfig
 from pipeline_core.fetchers import FetcherOrchestrator, RemoteAssetCandidate
 
@@ -69,3 +71,47 @@ def test_fetch_candidates_skip_video_providers_when_videos_disabled(monkeypatch)
 
     assert results == []
     assert run_calls == {"provider": 0, "fallback": 0}
+
+
+@pytest.mark.parametrize("provider_name", ["pexels", "pixabay"])
+def test_video_providers_allowed_when_images_disabled(monkeypatch, provider_name):
+    provider = ProviderConfig(
+        name=provider_name,
+        enabled=True,
+        max_results=3,
+        supports_images=False,
+        supports_videos=True,
+    )
+    config = FetcherOrchestratorConfig(
+        providers=(provider,),
+        allow_images=False,
+        allow_videos=True,
+        per_segment_limit=3,
+    )
+    orchestrator = FetcherOrchestrator(config)
+
+    monkeypatch.setenv("PEXELS_API_KEY", "token")
+    monkeypatch.setenv("PIXABAY_API_KEY", "token")
+
+    monkeypatch.setattr(
+        FetcherOrchestrator,
+        "_build_queries",
+        lambda self, keywords: ["demo"],
+    )
+
+    provider_calls = []
+
+    def _fake_run_provider_fetch(self, provider_conf, query, filters, segment_timeout):
+        provider_calls.append((provider_conf.name, query))
+        return []
+
+    def _fake_run_pixabay_fallback(self, queries, limit, *, segment_index=None):
+        return []
+
+    monkeypatch.setattr(FetcherOrchestrator, "_run_provider_fetch", _fake_run_provider_fetch)
+    monkeypatch.setattr(FetcherOrchestrator, "_run_pixabay_fallback", _fake_run_pixabay_fallback)
+
+    results = orchestrator.fetch_candidates(["demo"], filters=None)
+
+    assert results == []
+    assert provider_calls == [(provider_name, "demo")]


### PR DESCRIPTION
## Summary
- update the fetcher capability guard to keep providers that support at least one requested media type and log incapability skips
- ensure video-only providers such as Pexels and Pixabay remain eligible when videos are enabled but images are disabled
- expand unit coverage for capability filtering and provider eligibility

## Testing
- pytest tests/test_fetchers.py tests/test_provider_guard.py

------
https://chatgpt.com/codex/tasks/task_e_68dc5a6815248330864f4d2598919416