### PR TITLE
Log allow flags for skipped providers

### DIFF
--- a/pipeline_core/fetchers.py
+++ b/pipeline_core/fetchers.py
@@ -100,8 +100,8 @@ class FetcherOrchestrator:
                     self._log_event({
                         'event': 'provider_skipped_incapable',
                         'provider': getattr(provider_conf, 'name', ''),
-                        'requested_images': want_images,
-                        'requested_videos': want_videos,
+                        'allow_images': self.config.allow_images,
+                        'allow_videos': self.config.allow_videos,
                         'supports_images': supports_images,
                         'supports_videos': supports_videos,
                     })

--- a/tests/test_provider_guard.py
+++ b/tests/test_provider_guard.py
@@ -78,3 +78,5 @@ def test_provider_skipped_when_missing_capabilities(monkeypatch):
     assert results == []
     skipped = [evt for evt in logger.events if evt.get('event') == 'provider_skipped_incapable']
     assert skipped and skipped[0].get('provider') == 'images-only'
+    assert skipped[0].get('allow_images') is False
+    assert skipped[0].get('allow_videos') is True


### PR DESCRIPTION
## Summary
- include orchestrator allow flags in provider_skipped_incapable events
- verify the logged payload via provider guard unit test

## Testing
- pytest tests/test_provider_guard.py

------
https://chatgpt.com/codex/tasks/task_e_68dc5d270edc833090915f219d164841