### PR TITLE
Route dynamic context completions through Ollama

### DIFF
--- a/video_processor_current_backup.py
+++ b/video_processor_current_backup.py
@@ -440,7 +440,7 @@ from pipeline_core.logging import JsonlLogger, log_broll_decision, log_pipeline_
 
 from pipeline_core.runtime import PipelineResult, Stage
 
-from pipeline_core.llm_service import LLMMetadataGeneratorService
+from pipeline_core.llm_service import DynamicCompletionError, LLMMetadataGeneratorService
 
 # 🚀 NOUVEAU: Cache global pour éviter le rechargement des modèles
 
@@ -5150,6 +5150,10 @@ class VideoProcessor:
                 try:
 
                     dyn_context = self._llm_service.generate_dynamic_context(transcript_text_full)
+
+                except DynamicCompletionError as exc:
+
+                    dyn_context = exc.payload or {}
 
                 except Exception:
 


### PR DESCRIPTION
## Summary
- route dynamic completions through the Ollama text generator with explicit logging and error reasons
- propagate DynamicCompletionError payloads into dynamic context callers for TF-IDF fallbacks
- update unit tests to reflect the new DynamicCompletionError contract

## Testing
- pytest tests/test_llm_dynamic_context.py

------
https://chatgpt.com/codex/tasks/task_e_68e10fd31ab0833083f8dd5d40ea5fa1