### PR TITLE
Rename TF-IDF fallback environment flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ BROLL_FETCH_ALLOW_IMAGES=False
 BROLL_FETCH_MAX_PER_KEYWORD=8
 `
 
+### Variables d'environnement supplémentaires
+
+- `PIPELINE_TFIDF_FALLBACK_DISABLED` : lorsque défini sur une valeur vraie (`1`, `true`, `yes`...), le pipeline n'utilise
+  plus le secours TF-IDF pour la génération de contexte dynamique et les indices de segments. Cela permet de forcer un
+  échec explicite lorsque les réponses LLM ne sont pas disponibles ou jugées insuffisantes.
+  - L'ancien drapeau `PIPELINE_DISABLE_TFIDF_FALLBACK` reste pris en charge pour compatibilité mais émet désormais un
+    avertissement de dépréciation ; migrez vers le nouveau nom dès que possible.
+
 ##  Utilisation
 
 ### Interface Graphique (Recommandé)

--- a/pipeline_core/llm_service.py
+++ b/pipeline_core/llm_service.py
@@ -21,6 +21,8 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 import requests
 
+from pipeline_core.configuration import tfidf_fallback_disabled_from_env
+
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT))
 UTILS_DIR = PROJECT_ROOT / 'utils'
@@ -2408,7 +2410,7 @@ class LLMMetadataGeneratorService:
                 flag = _extract_disable_flag(getattr(source, "llm"))
             return flag
 
-        disable_flag = _env_to_bool(os.getenv("PIPELINE_DISABLE_TFIDF_FALLBACK"))
+        disable_flag = tfidf_fallback_disabled_from_env()
         if disable_flag is None:
             disable_flag = _extract_disable_flag(config)
         self._disable_tfidf_fallback = bool(disable_flag) if disable_flag is not None else False


### PR DESCRIPTION
## Summary
- replace the PIPELINE_DISABLE_TFIDF_FALLBACK flag with PIPELINE_TFIDF_FALLBACK_DISABLED and add a deprecation warning shim
- use the centralised helper in the LLM metadata service so the disable flag is cached once on construction
- document the new environment variable in the README and update tests for the renamed flag

## Testing
- pytest tests/test_llm_dynamic_context.py

------
https://chatgpt.com/codex/tasks/task_e_68e14fd9038483309251e7f5d17037f0