### PR TITLE
feat: add typed configuration bootstrap

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -q
+filterwarnings =
+    ignore::DeprecationWarning

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from tools.runtime_stamp import emit_runtime_banner
+from video_pipeline.config import load_settings, log_effective_settings
 
 try:
     from dotenv import load_dotenv
@@ -381,6 +382,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     load_dotenv(repo_root / '.env', override=False)
     load_dotenv(repo_root / '.env.local', override=True)
     _sanitize_env_values(_SANITIZE_KEYS)
+
+    settings = load_settings()
+    log_effective_settings(settings)
 
     parser = argparse.ArgumentParser(
         description="Launch the video pipeline with stable environment defaults."

--- a/tests/test_config_boot.py
+++ b/tests/test_config_boot.py
@@ -1,0 +1,125 @@
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from video_pipeline.config import load_settings, log_effective_settings
+
+
+@pytest.fixture(autouse=True)
+def _clear_custom_env(monkeypatch):
+    keys = [
+        "PIPELINE_LLM_TIMEOUT_S",
+        "PIPELINE_LLM_FALLBACK_TIMEOUT_S",
+        "PIPELINE_LLM_FORCE_NON_STREAM",
+        "PIPELINE_LLM_KEYWORDS_FIRST",
+        "PIPELINE_LLM_MODEL",
+        "PIPELINE_LLM_MODEL_JSON",
+        "PIPELINE_LLM_MODEL_TEXT",
+        "PIPELINE_LLM_JSON_PROMPT",
+        "PIPELINE_LLM_JSON_TRANSCRIPT_LIMIT",
+        "PIPELINE_BROLL_MIN_START_SECONDS",
+        "PIPELINE_BROLL_MIN_GAP_SECONDS",
+        "PIPELINE_BROLL_NO_REPEAT_SECONDS",
+        "PIPELINE_FETCH_TIMEOUT_S",
+        "BROLL_FETCH_MAX_PER_KEYWORD",
+        "BROLL_FETCH_ALLOW_IMAGES",
+        "BROLL_FETCH_ALLOW_VIDEOS",
+        "BROLL_FETCH_PROVIDER",
+        "BROLL_PEXELS_MAX_PER_KEYWORD",
+        "FETCH_MAX",
+        "PEXELS_API_KEY",
+        "PIXABAY_API_KEY",
+        "UNSPLASH_ACCESS_KEY",
+    ]
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+    yield
+
+
+def test_config_boot_parses_types(monkeypatch):
+    monkeypatch.setenv("PIPELINE_LLM_TIMEOUT_S", "42.5")
+    monkeypatch.setenv("PIPELINE_LLM_FALLBACK_TIMEOUT_S", "33")
+    monkeypatch.setenv("PIPELINE_LLM_FORCE_NON_STREAM", "yes")
+    monkeypatch.setenv("PIPELINE_LLM_KEYWORDS_FIRST", "0")
+    monkeypatch.setenv("PIPELINE_LLM_JSON_PROMPT", "  custom ")
+    monkeypatch.setenv("PIPELINE_LLM_JSON_TRANSCRIPT_LIMIT", "128")
+    monkeypatch.setenv("PIPELINE_BROLL_MIN_START_SECONDS", "2.75")
+    monkeypatch.setenv("PIPELINE_BROLL_MIN_GAP_SECONDS", "1.25")
+    monkeypatch.setenv("PIPELINE_BROLL_NO_REPEAT_SECONDS", "9.0")
+    monkeypatch.setenv("PIPELINE_FETCH_TIMEOUT_S", "9.5")
+    monkeypatch.setenv("BROLL_FETCH_MAX_PER_KEYWORD", "5")
+    monkeypatch.setenv("BROLL_FETCH_ALLOW_IMAGES", "no")
+    monkeypatch.setenv("BROLL_FETCH_ALLOW_VIDEOS", "1")
+    monkeypatch.setenv("BROLL_FETCH_PROVIDER", " pixabay , Pexels ")
+    monkeypatch.setenv("BROLL_PEXELS_MAX_PER_KEYWORD", "4")
+
+    settings = load_settings()
+
+    assert settings.llm.timeout_stream_s == pytest.approx(42.5)
+    assert settings.llm.timeout_fallback_s == pytest.approx(33.0)
+    assert settings.llm.force_non_stream is True
+    assert settings.llm.keywords_first is False
+    assert settings.llm.json_prompt == "custom"
+    assert settings.llm.json_transcript_limit == 128
+
+    assert settings.broll.min_start_s == pytest.approx(2.75)
+    assert settings.broll.min_gap_s == pytest.approx(1.25)
+    assert settings.broll.no_repeat_s == pytest.approx(9.0)
+
+    assert settings.fetch.timeout_s == pytest.approx(9.5)
+    assert settings.fetch.max_per_keyword == 5
+    assert settings.fetch.allow_images is False
+    assert settings.fetch.allow_videos is True
+    assert settings.fetch.providers == ("pixabay", "pexels")
+    assert settings.fetch.provider_limits["pexels"] == 4
+
+
+def test_config_boot_log_masks_sensitive_keys(monkeypatch):
+    monkeypatch.setenv("PIPELINE_LLM_MODEL", "llama")
+    monkeypatch.setenv("PEXELS_API_KEY", "pexels-secret")
+    monkeypatch.setenv("PIXABAY_API_KEY", "pixabay-secret")
+
+    settings = load_settings()
+
+    logger = logging.getLogger("video_pipeline.config")
+    records: list[logging.LogRecord] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - trivial
+            records.append(record)
+
+    handler = _Collector()
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    try:
+        log_effective_settings(settings)
+    finally:
+        logger.removeHandler(handler)
+
+    assert records, "no startup log emitted"
+
+    message = records[0].message
+    assert message.startswith("[CONFIG] effective=")
+
+    payload = json.loads(message.split("=", 1)[1])
+    fetch_payload = payload["fetch"]
+    assert fetch_payload["api_keys"]["PEXELS_API_KEY"] == "****cret"
+    assert fetch_payload["api_keys"]["PIXABAY_API_KEY"] == "****cret"
+
+
+def test_config_boot_effective_models_use_defaults(monkeypatch):
+    monkeypatch.setenv("PIPELINE_LLM_MODEL", "qwen-main")
+    monkeypatch.delenv("PIPELINE_LLM_MODEL_JSON", raising=False)
+    monkeypatch.delenv("PIPELINE_LLM_MODEL_TEXT", raising=False)
+
+    settings = load_settings()
+
+    assert settings.llm.effective_json_model == "qwen-main"
+    assert settings.llm.effective_text_model == "qwen-main"
+    payload = settings.to_log_payload()
+    assert payload["llm"]["model_json"] == "qwen-main"
+    assert payload["llm"]["model_text"] == "qwen-main"
+    assert Path(payload["paths"]["output_dir"]).name == "output"
+

--- a/video_pipeline/config/__init__.py
+++ b/video_pipeline/config/__init__.py
@@ -1,0 +1,30 @@
+"""Configuration helpers for the video pipeline."""
+from .settings import (
+    Settings,
+    BrollSettings,
+    FetchSettings,
+    LLMSettings,
+    LogSettings,
+    csv_list,
+    load_settings,
+    log_effective_settings,
+    mask,
+    to_bool,
+    to_float,
+    to_int,
+)
+
+__all__ = [
+    "Settings",
+    "BrollSettings",
+    "FetchSettings",
+    "LLMSettings",
+    "LogSettings",
+    "csv_list",
+    "load_settings",
+    "log_effective_settings",
+    "mask",
+    "to_bool",
+    "to_float",
+    "to_int",
+]

--- a/video_pipeline/config/settings.py
+++ b/video_pipeline/config/settings.py
@@ -1,0 +1,322 @@
+"""Strongly typed configuration loader for the pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Mapping
+
+TRUE_VALUES = {"1", "true", "yes", "on"}
+FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+def _clean(value: str | None) -> str:
+    if value is None:
+        return ""
+    return value.strip()
+
+
+def to_bool(value: object | None, default: bool = False) -> bool:
+    """Convert an environment value to ``bool`` with graceful fallback."""
+    if value is None:
+        return bool(default)
+    text = _clean(str(value)).lower()
+    if not text:
+        return bool(default)
+    if text in TRUE_VALUES:
+        return True
+    if text in FALSE_VALUES:
+        return False
+    return bool(default)
+
+
+def to_int(value: object | None, default: int) -> int:
+    """Convert *value* to ``int`` when possible, otherwise ``default``."""
+    if value is None:
+        return int(default)
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return int(default)
+
+
+def to_float(value: object | None, default: float) -> float:
+    """Convert *value* to ``float`` when possible, otherwise ``default``."""
+    if value is None:
+        return float(default)
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def csv_list(value: object | None) -> list[str]:
+    """Return a normalized list from a comma separated value."""
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    text = str(value)
+    parts = [segment.strip() for segment in text.split(",")]
+    return [segment for segment in parts if segment]
+
+
+def mask(value: object | None) -> str | None:
+    """Return a masked representation for secret configuration entries."""
+    if value is None:
+        return None
+    text = _clean(str(value))
+    if not text:
+        return None
+    if len(text) <= 4:
+        return f"****{text}"
+    return f"****{text[-4:]}"
+
+
+@dataclass(slots=True)
+class LLMSettings:
+    model: str = "qwen2.5:7b"
+    model_json: str = ""
+    model_text: str = ""
+    endpoint: str = "http://localhost:11434"
+    base_url: str = "http://localhost:11434"
+    keep_alive: str = "30m"
+    timeout_stream_s: float = 60.0
+    timeout_fallback_s: float = 45.0
+    min_chars: int = 8
+    max_attempts: int = 3
+    num_predict: int = 256
+    temperature: float = 0.3
+    top_p: float = 0.9
+    repeat_penalty: float = 1.1
+    num_ctx: int = 4096
+    fallback_trunc: int = 3500
+    force_non_stream: bool = False
+    keywords_first: bool = True
+    disable_hashtags: bool = False
+    target_lang: str = "en"
+    json_prompt: str | None = None
+    json_mode: bool = False
+    json_transcript_limit: int | None = None
+
+    @property
+    def effective_json_model(self) -> str:
+        return self.model_json or self.model
+
+    @property
+    def effective_text_model(self) -> str:
+        return self.model_text or self.model
+
+
+@dataclass(slots=True)
+class BrollSettings:
+    min_start_s: float = 2.0
+    min_gap_s: float = 1.5
+    no_repeat_s: float = 6.0
+
+
+@dataclass(slots=True)
+class FetchSettings:
+    max_per_keyword: int = 8
+    allow_images: bool = True
+    allow_videos: bool = True
+    providers: tuple[str, ...] = ("pixabay",)
+    provider_limits: dict[str, int] = field(default_factory=dict)
+    timeout_s: float = 8.0
+    api_keys: dict[str, str | None] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class LogSettings:
+    logger_name: str = "video_pipeline.config"
+    startup_label: str = "[CONFIG]"
+    masked_env_keys: tuple[str, ...] = (
+        "PEXELS_API_KEY",
+        "PIXABAY_API_KEY",
+        "UNSPLASH_ACCESS_KEY",
+    )
+
+
+@dataclass(slots=True)
+class Settings:
+    clips_dir: Path
+    output_dir: Path
+    temp_dir: Path
+    llm: LLMSettings
+    broll: BrollSettings
+    fetch: FetchSettings
+    log: LogSettings = field(default_factory=LogSettings)
+
+    def to_log_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "paths": {
+                "clips_dir": str(self.clips_dir),
+                "output_dir": str(self.output_dir),
+                "temp_dir": str(self.temp_dir),
+            },
+            "llm": {
+                "model": self.llm.model,
+                "model_json": self.llm.effective_json_model,
+                "model_text": self.llm.effective_text_model,
+                "endpoint": self.llm.endpoint,
+                "keep_alive": self.llm.keep_alive,
+                "timeout_stream_s": self.llm.timeout_stream_s,
+                "timeout_fallback_s": self.llm.timeout_fallback_s,
+                "min_chars": self.llm.min_chars,
+                "max_attempts": self.llm.max_attempts,
+            },
+            "broll": {
+                "min_start_s": self.broll.min_start_s,
+                "min_gap_s": self.broll.min_gap_s,
+                "no_repeat_s": self.broll.no_repeat_s,
+            },
+            "fetch": {
+                "max_per_keyword": self.fetch.max_per_keyword,
+                "allow_images": self.fetch.allow_images,
+                "allow_videos": self.fetch.allow_videos,
+                "providers": list(self.fetch.providers),
+                "provider_limits": dict(self.fetch.provider_limits),
+                "timeout_s": self.fetch.timeout_s,
+            },
+        }
+
+        masked_keys: dict[str, str | None] = {}
+        for key in self.log.masked_env_keys:
+            masked_keys[key] = mask(self.fetch.api_keys.get(key))
+        if masked_keys:
+            payload["fetch"]["api_keys"] = masked_keys
+
+        return payload
+
+
+def _get_env(source: Mapping[str, str] | None, key: str, default: str | None = None) -> str | None:
+    if source is None:
+        return os.getenv(key, default) if default is not None else os.getenv(key)
+    return source.get(key, default)
+
+
+def load_settings(env: Mapping[str, str] | None = None) -> Settings:
+    """Load :class:`Settings` from the provided mapping or ``os.environ``."""
+    clips_dir = Path(_get_env(env, "PIPELINE_CLIPS_DIR", "clips") or "clips")
+    output_dir = Path(_get_env(env, "PIPELINE_OUTPUT_DIR", "output") or "output")
+    temp_dir = Path(_get_env(env, "PIPELINE_TEMP_DIR", "temp") or "temp")
+
+    llm_model = _clean(_get_env(env, "PIPELINE_LLM_MODEL", "qwen2.5:7b") or "qwen2.5:7b")
+    llm_model_json = _clean(_get_env(env, "PIPELINE_LLM_MODEL_JSON", "") or "")
+    llm_model_text = _clean(_get_env(env, "PIPELINE_LLM_MODEL_TEXT", "") or "")
+    llm_endpoint = _clean(
+        _get_env(env, "PIPELINE_LLM_ENDPOINT")
+        or _get_env(env, "PIPELINE_LLM_BASE_URL")
+        or "http://localhost:11434"
+    )
+    llm_keep_alive = _clean(_get_env(env, "PIPELINE_LLM_KEEP_ALIVE", "30m") or "30m")
+    llm_timeout_stream = to_float(_get_env(env, "PIPELINE_LLM_TIMEOUT_S", "60"), 60.0)
+    llm_timeout_fallback = to_float(_get_env(env, "PIPELINE_LLM_FALLBACK_TIMEOUT_S", "45"), 45.0)
+    llm_min_chars = to_int(_get_env(env, "PIPELINE_LLM_MIN_CHARS", "8"), 8)
+    llm_max_attempts = to_int(_get_env(env, "PIPELINE_LLM_MAX_ATTEMPTS", "3"), 3)
+    llm_num_predict = to_int(_get_env(env, "PIPELINE_LLM_NUM_PREDICT", "256"), 256)
+    llm_temperature = to_float(_get_env(env, "PIPELINE_LLM_TEMP", "0.3"), 0.3)
+    llm_top_p = to_float(_get_env(env, "PIPELINE_LLM_TOP_P", "0.9"), 0.9)
+    llm_repeat_penalty = to_float(_get_env(env, "PIPELINE_LLM_REPEAT_PENALTY", "1.1"), 1.1)
+    llm_num_ctx = to_int(_get_env(env, "PIPELINE_LLM_NUM_CTX", "4096"), 4096)
+    llm_fallback_trunc = to_int(_get_env(env, "PIPELINE_LLM_FALLBACK_TRUNC", "3500"), 3500)
+    llm_force_non_stream = to_bool(_get_env(env, "PIPELINE_LLM_FORCE_NON_STREAM"), False)
+    llm_keywords_first = to_bool(_get_env(env, "PIPELINE_LLM_KEYWORDS_FIRST"), True)
+    llm_disable_hashtags = to_bool(_get_env(env, "PIPELINE_LLM_DISABLE_HASHTAGS"), False)
+    llm_target_lang = _clean(_get_env(env, "PIPELINE_LLM_TARGET_LANG", "en") or "en")
+    llm_json_prompt = _clean(_get_env(env, "PIPELINE_LLM_JSON_PROMPT") or "") or None
+    llm_json_mode = to_bool(_get_env(env, "PIPELINE_LLM_JSON_MODE"), False)
+    llm_json_transcript_limit_raw = _clean(_get_env(env, "PIPELINE_LLM_JSON_TRANSCRIPT_LIMIT") or "")
+    llm_json_transcript_limit = None
+    if llm_json_transcript_limit_raw:
+        llm_json_transcript_limit = to_int(llm_json_transcript_limit_raw, 0)
+
+    llm_settings = LLMSettings(
+        model=llm_model,
+        model_json=llm_model_json,
+        model_text=llm_model_text,
+        endpoint=llm_endpoint,
+        base_url=llm_endpoint,
+        keep_alive=llm_keep_alive,
+        timeout_stream_s=llm_timeout_stream,
+        timeout_fallback_s=llm_timeout_fallback,
+        min_chars=llm_min_chars,
+        max_attempts=llm_max_attempts,
+        num_predict=llm_num_predict,
+        temperature=llm_temperature,
+        top_p=llm_top_p,
+        repeat_penalty=llm_repeat_penalty,
+        num_ctx=llm_num_ctx,
+        fallback_trunc=llm_fallback_trunc,
+        force_non_stream=llm_force_non_stream,
+        keywords_first=llm_keywords_first,
+        disable_hashtags=llm_disable_hashtags,
+        target_lang=llm_target_lang,
+        json_prompt=llm_json_prompt,
+        json_mode=llm_json_mode,
+        json_transcript_limit=llm_json_transcript_limit,
+    )
+
+    broll_settings = BrollSettings(
+        min_start_s=to_float(_get_env(env, "PIPELINE_BROLL_MIN_START_SECONDS", "2.0"), 2.0),
+        min_gap_s=to_float(_get_env(env, "PIPELINE_BROLL_MIN_GAP_SECONDS", "1.5"), 1.5),
+        no_repeat_s=to_float(_get_env(env, "PIPELINE_BROLL_NO_REPEAT_SECONDS", "6.0"), 6.0),
+    )
+
+    provider_values = csv_list(
+        _get_env(env, "BROLL_FETCH_PROVIDER")
+        or _get_env(env, "AI_BROLL_FETCH_PROVIDER")
+    )
+    if not provider_values:
+        provider_values = ["pixabay"]
+
+    provider_limits: dict[str, int] = {}
+    for provider in provider_values:
+        env_key = f"BROLL_{provider.upper()}_MAX_PER_KEYWORD"
+        limit = _get_env(env, env_key)
+        if limit is not None:
+            provider_limits[provider.lower()] = to_int(limit, 1)
+
+    fetch_timeout = to_float(_get_env(env, "PIPELINE_FETCH_TIMEOUT_S", "8"), 8.0)
+    fetch_max_default = to_int(_get_env(env, "FETCH_MAX", "8"), 8)
+    fetch_max_per_keyword = to_int(
+        _get_env(env, "BROLL_FETCH_MAX_PER_KEYWORD"),
+        fetch_max_default,
+    )
+
+    fetch_settings = FetchSettings(
+        max_per_keyword=fetch_max_per_keyword,
+        allow_images=to_bool(_get_env(env, "BROLL_FETCH_ALLOW_IMAGES"), True),
+        allow_videos=to_bool(_get_env(env, "BROLL_FETCH_ALLOW_VIDEOS"), True),
+        providers=tuple(p.lower() for p in provider_values),
+        provider_limits=provider_limits,
+        timeout_s=fetch_timeout,
+        api_keys={
+            "PEXELS_API_KEY": _get_env(env, "PEXELS_API_KEY"),
+            "PIXABAY_API_KEY": _get_env(env, "PIXABAY_API_KEY"),
+            "UNSPLASH_ACCESS_KEY": _get_env(env, "UNSPLASH_ACCESS_KEY"),
+        },
+    )
+
+    log_settings = LogSettings()
+
+    return Settings(
+        clips_dir=clips_dir,
+        output_dir=output_dir,
+        temp_dir=temp_dir,
+        llm=llm_settings,
+        broll=broll_settings,
+        fetch=fetch_settings,
+        log=log_settings,
+    )
+
+
+def log_effective_settings(settings: Settings, logger: logging.Logger | None = None) -> None:
+    """Emit a single startup log describing the effective configuration."""
+    logger = logger or logging.getLogger(settings.log.logger_name)
+    payload = settings.to_log_payload()
+    message = f"{settings.log.startup_label} effective={json.dumps(payload, sort_keys=True)}"
+    logger.info(message)
+


### PR DESCRIPTION
## Summary
- implement the video_pipeline.config package with typed settings helpers and startup logging
- call the startup configuration logger in run_pipeline and add pytest defaults
- cover the configuration loader with config_boot focused tests

## Testing
- pytest -q --capture=sys tests/test_config_boot.py -k config_boot


------
https://chatgpt.com/codex/tasks/task_e_68e3b2c97cec83308b2b3c8e70696142