### PR TITLE
chore: restore typed config bootstrapping

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -13,6 +13,11 @@
 ## Vue d'ensemble
 Le dépôt orchestre un pipeline complet de génération de clips verticaux : transcription, extraction d'insights via LLM, requêtes B-roll auprès de Pexels/Pixabay, insertion vidéo et rendu final. Le wrapper CLI `run_pipeline.py` prépare l'environnement (UTF-8, clés API, configuration fetcher) avant de déléguer à `video_processor.VideoProcessor` pour gérer les étapes vidéo, audio et B-roll.【F:run_pipeline.py†L1-L200】【F:video_processor.py†L1843-L1999】
 
+## Résolu — Lot 1 merge
+- **Fichiers touchés** : `run_pipeline.py`, `video_pipeline/config/settings.py`, `video_pipeline/config/__init__.py`, `tests/test_config_boot.py`, `config.py`.
+- **Décisions clés** : réintroduction du chargeur de configuration typé avec cache process-wide, log `[CONFIG]` idempotent et masquage des secrets, avertissement de dépréciation pour `config.py` afin d'orienter vers l'API unifiée.
+- **Suites possibles (Lots 2/3)** : brancher ces settings typés sur la sélection B-roll avancée et enrichir les validations/contrôles dans `pipeline_core.configuration` sans modifier le point d'entrée CLI.
+
 ## Carte des modules
 ```mermaid
 graph TD

--- a/config.py
+++ b/config.py
@@ -1,5 +1,20 @@
 import os
+import warnings
 from pathlib import Path
+
+from video_pipeline.config import get_settings as _typed_get_settings
+
+warnings.warn(
+    "config.py is deprecated; import video_pipeline.config instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+def get_settings():
+    """Return the shared typed settings instance."""
+
+    return _typed_get_settings()
 
 # Configuration principale pour compatibilité avec le pipeline
 class Config:

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 from tools.runtime_stamp import emit_runtime_banner
-from video_pipeline.config import load_settings, log_effective_settings
+from video_pipeline.config import (
+    get_settings,
+    load_settings,
+    log_effective_settings,
+    set_settings,
+)
 
 try:
     from dotenv import load_dotenv
@@ -384,6 +389,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     _sanitize_env_values(_SANITIZE_KEYS)
 
     settings = load_settings()
+    set_settings(settings)
+    settings = get_settings()
     log_effective_settings(settings)
 
     parser = argparse.ArgumentParser(

--- a/tests/test_config_boot.py
+++ b/tests/test_config_boot.py
@@ -4,82 +4,155 @@ from pathlib import Path
 
 import pytest
 
-from video_pipeline.config import load_settings, log_effective_settings
+from video_pipeline.config import (
+    load_settings,
+    log_effective_settings,
+    reset_startup_log_for_tests,
+)
 
 
 @pytest.fixture(autouse=True)
-def _clear_custom_env(monkeypatch):
+def _reset_config(monkeypatch):
     keys = [
         "PIPELINE_LLM_TIMEOUT_S",
         "PIPELINE_LLM_FALLBACK_TIMEOUT_S",
         "PIPELINE_LLM_FORCE_NON_STREAM",
         "PIPELINE_LLM_KEYWORDS_FIRST",
+        "PIPELINE_LLM_DISABLE_HASHTAGS",
         "PIPELINE_LLM_MODEL",
         "PIPELINE_LLM_MODEL_JSON",
         "PIPELINE_LLM_MODEL_TEXT",
         "PIPELINE_LLM_JSON_PROMPT",
+        "PIPELINE_LLM_JSON_MODE",
         "PIPELINE_LLM_JSON_TRANSCRIPT_LIMIT",
+        "PIPELINE_LLM_TEMP",
+        "PIPELINE_LLM_TOP_P",
+        "PIPELINE_LLM_REPEAT_PENALTY",
+        "PIPELINE_LLM_MIN_CHARS",
+        "PIPELINE_LLM_MAX_ATTEMPTS",
+        "PIPELINE_LLM_NUM_PREDICT",
+        "PIPELINE_LLM_NUM_CTX",
+        "PIPELINE_LLM_FALLBACK_TRUNC",
+        "PIPELINE_LLM_TARGET_LANG",
         "PIPELINE_BROLL_MIN_START_SECONDS",
         "PIPELINE_BROLL_MIN_GAP_SECONDS",
         "PIPELINE_BROLL_NO_REPEAT_SECONDS",
         "PIPELINE_FETCH_TIMEOUT_S",
         "BROLL_FETCH_MAX_PER_KEYWORD",
+        "FETCH_MAX",
         "BROLL_FETCH_ALLOW_IMAGES",
         "BROLL_FETCH_ALLOW_VIDEOS",
         "BROLL_FETCH_PROVIDER",
+        "AI_BROLL_FETCH_PROVIDER",
         "BROLL_PEXELS_MAX_PER_KEYWORD",
-        "FETCH_MAX",
+        "PIPELINE_TFIDF_FALLBACK_DISABLED",
+        "PIPELINE_DISABLE_TFIDF_FALLBACK",
+        "PIPELINE_LLM_MAX_QUERIES_PER_SEGMENT",
+        "PIPELINE_FAST_TESTS",
+        "PIPELINE_MAX_SEGMENTS_IN_FLIGHT",
+        "PIPELINE_CLIPS_DIR",
+        "PIPELINE_OUTPUT_DIR",
+        "PIPELINE_TEMP_DIR",
         "PEXELS_API_KEY",
         "PIXABAY_API_KEY",
         "UNSPLASH_ACCESS_KEY",
     ]
     for key in keys:
         monkeypatch.delenv(key, raising=False)
+    reset_startup_log_for_tests()
     yield
 
 
-def test_config_boot_parses_types(monkeypatch):
+def test_config_boot_parses_types_and_clamps(monkeypatch):
     monkeypatch.setenv("PIPELINE_LLM_TIMEOUT_S", "42.5")
-    monkeypatch.setenv("PIPELINE_LLM_FALLBACK_TIMEOUT_S", "33")
+    monkeypatch.setenv("PIPELINE_LLM_FALLBACK_TIMEOUT_S", "-3")  # clamp to 0
     monkeypatch.setenv("PIPELINE_LLM_FORCE_NON_STREAM", "yes")
     monkeypatch.setenv("PIPELINE_LLM_KEYWORDS_FIRST", "0")
+    monkeypatch.setenv("PIPELINE_LLM_DISABLE_HASHTAGS", "TRUE")
     monkeypatch.setenv("PIPELINE_LLM_JSON_PROMPT", "  custom ")
-    monkeypatch.setenv("PIPELINE_LLM_JSON_TRANSCRIPT_LIMIT", "128")
+    monkeypatch.setenv("PIPELINE_LLM_JSON_MODE", "1")
+    monkeypatch.setenv("PIPELINE_LLM_JSON_TRANSCRIPT_LIMIT", "-5")
+    monkeypatch.setenv("PIPELINE_LLM_TEMP", "-1")
+    monkeypatch.setenv("PIPELINE_LLM_TOP_P", "0.95")
+    monkeypatch.setenv("PIPELINE_LLM_REPEAT_PENALTY", "0.0")
+    monkeypatch.setenv("PIPELINE_LLM_MIN_CHARS", "-4")
+    monkeypatch.setenv("PIPELINE_LLM_MAX_ATTEMPTS", "0")
+    monkeypatch.setenv("PIPELINE_LLM_NUM_PREDICT", "1024")
+    monkeypatch.setenv("PIPELINE_LLM_NUM_CTX", "-1")
+    monkeypatch.setenv("PIPELINE_LLM_FALLBACK_TRUNC", "100")
+    monkeypatch.setenv("PIPELINE_LLM_TARGET_LANG", " FR ")
     monkeypatch.setenv("PIPELINE_BROLL_MIN_START_SECONDS", "2.75")
-    monkeypatch.setenv("PIPELINE_BROLL_MIN_GAP_SECONDS", "1.25")
+    monkeypatch.setenv("PIPELINE_BROLL_MIN_GAP_SECONDS", "-1")
     monkeypatch.setenv("PIPELINE_BROLL_NO_REPEAT_SECONDS", "9.0")
-    monkeypatch.setenv("PIPELINE_FETCH_TIMEOUT_S", "9.5")
-    monkeypatch.setenv("BROLL_FETCH_MAX_PER_KEYWORD", "5")
+    monkeypatch.setenv("PIPELINE_FETCH_TIMEOUT_S", "-9.5")
+    monkeypatch.setenv("BROLL_FETCH_MAX_PER_KEYWORD", "0")
+    monkeypatch.setenv("FETCH_MAX", "12")
     monkeypatch.setenv("BROLL_FETCH_ALLOW_IMAGES", "no")
     monkeypatch.setenv("BROLL_FETCH_ALLOW_VIDEOS", "1")
-    monkeypatch.setenv("BROLL_FETCH_PROVIDER", " pixabay , Pexels ")
-    monkeypatch.setenv("BROLL_PEXELS_MAX_PER_KEYWORD", "4")
+    monkeypatch.setenv("BROLL_FETCH_PROVIDER", " pixabay , Pexels ,pixabay ")
+    monkeypatch.setenv("BROLL_PEXELS_MAX_PER_KEYWORD", "-4")
+    monkeypatch.setenv("PIPELINE_LLM_MAX_QUERIES_PER_SEGMENT", "0")
+    monkeypatch.setenv("PIPELINE_FAST_TESTS", "true")
+    monkeypatch.setenv("PIPELINE_MAX_SEGMENTS_IN_FLIGHT", "-2")
 
     settings = load_settings()
 
     assert settings.llm.timeout_stream_s == pytest.approx(42.5)
-    assert settings.llm.timeout_fallback_s == pytest.approx(33.0)
+    assert settings.llm.timeout_fallback_s == pytest.approx(0.0)
     assert settings.llm.force_non_stream is True
     assert settings.llm.keywords_first is False
+    assert settings.llm.disable_hashtags is True
     assert settings.llm.json_prompt == "custom"
-    assert settings.llm.json_transcript_limit == 128
+    assert settings.llm.json_mode is True
+    assert settings.llm.json_transcript_limit == 0
+    assert settings.llm.temperature == pytest.approx(0.0)
+    assert settings.llm.top_p == pytest.approx(0.95)
+    assert settings.llm.repeat_penalty == pytest.approx(0.0)
+    assert settings.llm.min_chars == 0
+    assert settings.llm.max_attempts == 1
+    assert settings.llm.num_predict == 1024
+    assert settings.llm.num_ctx == 1
+    assert settings.llm.fallback_trunc == 100
+    assert settings.llm.target_lang == "FR"
 
     assert settings.broll.min_start_s == pytest.approx(2.75)
-    assert settings.broll.min_gap_s == pytest.approx(1.25)
+    assert settings.broll.min_gap_s == pytest.approx(0.0)
     assert settings.broll.no_repeat_s == pytest.approx(9.0)
 
-    assert settings.fetch.timeout_s == pytest.approx(9.5)
-    assert settings.fetch.max_per_keyword == 5
+    assert settings.fetch.timeout_s == pytest.approx(0.0)
+    assert settings.fetch.max_per_keyword == 1
     assert settings.fetch.allow_images is False
     assert settings.fetch.allow_videos is True
-    assert settings.fetch.providers == ("pixabay", "pexels")
-    assert settings.fetch.provider_limits["pexels"] == 4
+    assert settings.fetch.providers == ["pixabay", "pexels"]
+    assert settings.fetch.provider_limits["pexels"] == 1
+
+    assert settings.llm_max_queries_per_segment == 1
+    assert settings.fast_tests is True
+    assert settings.max_segments_in_flight == 1
 
 
-def test_config_boot_log_masks_sensitive_keys(monkeypatch):
+def test_config_boot_aliases_and_paths(monkeypatch, tmp_path):
+    clips = tmp_path / "clips"
+    output = tmp_path / "out"
+    temp = tmp_path / "tmp"
+    monkeypatch.setenv("PIPELINE_CLIPS_DIR", str(clips))
+    monkeypatch.setenv("PIPELINE_OUTPUT_DIR", str(output))
+    monkeypatch.setenv("PIPELINE_TEMP_DIR", str(temp))
+    monkeypatch.setenv("PIPELINE_DISABLE_TFIDF_FALLBACK", "1")
+
+    settings = load_settings()
+
+    assert settings.clips_dir == clips
+    assert settings.output_dir == output
+    assert settings.temp_dir == temp
+    assert settings.tfidf_fallback_disabled is True
+
+
+def test_config_boot_log_masks_secrets_and_is_idempotent(monkeypatch):
     monkeypatch.setenv("PIPELINE_LLM_MODEL", "llama")
     monkeypatch.setenv("PEXELS_API_KEY", "pexels-secret")
     monkeypatch.setenv("PIXABAY_API_KEY", "pixabay-secret")
+    monkeypatch.setenv("UNSPLASH_ACCESS_KEY", "ab")
 
     settings = load_settings()
 
@@ -95,18 +168,19 @@ def test_config_boot_log_masks_sensitive_keys(monkeypatch):
     logger.setLevel(logging.INFO)
     try:
         log_effective_settings(settings)
+        log_effective_settings(settings)
     finally:
         logger.removeHandler(handler)
 
-    assert records, "no startup log emitted"
-
-    message = records[0].message
+    assert len(records) == 1
+    message = records[0].getMessage()
     assert message.startswith("[CONFIG] effective=")
 
     payload = json.loads(message.split("=", 1)[1])
-    fetch_payload = payload["fetch"]
-    assert fetch_payload["api_keys"]["PEXELS_API_KEY"] == "****cret"
-    assert fetch_payload["api_keys"]["PIXABAY_API_KEY"] == "****cret"
+    api_keys = payload["fetch"]["api_keys"]
+    assert api_keys["PEXELS_API_KEY"] == "****cret"
+    assert api_keys["PIXABAY_API_KEY"] == "****cret"
+    assert api_keys["UNSPLASH_ACCESS_KEY"] == "****ab"
 
 
 def test_config_boot_effective_models_use_defaults(monkeypatch):

--- a/video_pipeline/config/__init__.py
+++ b/video_pipeline/config/__init__.py
@@ -1,30 +1,26 @@
-"""Configuration helpers for the video pipeline."""
+"""Public configuration API for the video pipeline."""
+
 from .settings import (
     Settings,
-    BrollSettings,
-    FetchSettings,
     LLMSettings,
-    LogSettings,
-    csv_list,
+    FetchSettings,
+    BrollSettings,
     load_settings,
+    get_settings,
+    set_settings,
     log_effective_settings,
-    mask,
-    to_bool,
-    to_float,
-    to_int,
+    reset_startup_log_for_tests,
 )
 
 __all__ = [
     "Settings",
-    "BrollSettings",
-    "FetchSettings",
     "LLMSettings",
-    "LogSettings",
-    "csv_list",
+    "FetchSettings",
+    "BrollSettings",
     "load_settings",
+    "get_settings",
+    "set_settings",
     "log_effective_settings",
-    "mask",
-    "to_bool",
-    "to_float",
-    "to_int",
+    "reset_startup_log_for_tests",
 ]
+

--- a/video_pipeline/config/settings.py
+++ b/video_pipeline/config/settings.py
@@ -1,105 +1,140 @@
-"""Strongly typed configuration loader for the pipeline."""
+"""Strongly typed configuration loader for the video pipeline."""
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import json
 import logging
 import os
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Mapping
-
-TRUE_VALUES = {"1", "true", "yes", "on"}
-FALSE_VALUES = {"0", "false", "no", "off"}
+from threading import Lock
+from typing import Dict, List, Mapping, Optional
 
 
-def _clean(value: str | None) -> str:
-    if value is None:
-        return ""
-    return value.strip()
+_TRUE_VALUES = {"1", "true", "t", "yes", "y", "on"}
+_FALSE_VALUES = {"0", "false", "f", "no", "n", "off"}
+
+_SETTINGS_CACHE: Optional["Settings"] = None
+_CACHE_LOCK = Lock()
+_STARTUP_LOG_EMITTED = False
 
 
-def to_bool(value: object | None, default: bool = False) -> bool:
-    """Convert an environment value to ``bool`` with graceful fallback."""
+def _clean_text(value: Optional[str]) -> str:
+    return value.strip() if value else ""
+
+
+def _coerce_bool(value: object | None, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
     if value is None:
         return bool(default)
-    text = _clean(str(value)).lower()
+    text = _clean_text(str(value)).lower()
     if not text:
         return bool(default)
-    if text in TRUE_VALUES:
+    if text in _TRUE_VALUES:
         return True
-    if text in FALSE_VALUES:
+    if text in _FALSE_VALUES:
         return False
     return bool(default)
 
 
-def to_int(value: object | None, default: int) -> int:
-    """Convert *value* to ``int`` when possible, otherwise ``default``."""
+def _coerce_float(
+    value: object | None,
+    default: float,
+    *,
+    minimum: float | None = None,
+) -> float:
     if value is None:
-        return int(default)
-    try:
-        return int(str(value).strip())
-    except (TypeError, ValueError):
-        return int(default)
+        result = float(default)
+    else:
+        try:
+            result = float(str(value).strip())
+        except (TypeError, ValueError):
+            result = float(default)
+    if minimum is not None and result < minimum:
+        result = float(minimum)
+    return result
 
 
-def to_float(value: object | None, default: float) -> float:
-    """Convert *value* to ``float`` when possible, otherwise ``default``."""
+def _coerce_int(
+    value: object | None,
+    default: int,
+    *,
+    minimum: int | None = None,
+) -> int:
     if value is None:
-        return float(default)
-    try:
-        return float(str(value).strip())
-    except (TypeError, ValueError):
-        return float(default)
+        result = int(default)
+    else:
+        try:
+            result = int(str(value).strip())
+        except (TypeError, ValueError):
+            result = int(default)
+    if minimum is not None and result < minimum:
+        result = int(minimum)
+    return result
 
 
-def csv_list(value: object | None) -> list[str]:
-    """Return a normalized list from a comma separated value."""
+def _split_csv(value: object | None) -> List[str]:
     if value is None:
         return []
-    if isinstance(value, (list, tuple)):
-        return [str(item).strip() for item in value if str(item).strip()]
-    text = str(value)
-    parts = [segment.strip() for segment in text.split(",")]
-    return [segment for segment in parts if segment]
+    if isinstance(value, (list, tuple, set)):
+        items = [str(item).strip() for item in value]
+    else:
+        text = str(value).replace(";", ",")
+        items = [chunk.strip() for chunk in text.split(",")]
+    cleaned: List[str] = []
+    seen = set()
+    for item in items:
+        if not item:
+            continue
+        lowered = item.lower()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        cleaned.append(lowered)
+    return cleaned
 
 
-def mask(value: object | None) -> str | None:
-    """Return a masked representation for secret configuration entries."""
-    if value is None:
+def _mask_secret(value: Optional[str]) -> Optional[str]:
+    if not value:
         return None
-    text = _clean(str(value))
-    if not text:
+    trimmed = value.strip()
+    if not trimmed:
         return None
-    if len(text) <= 4:
-        return f"****{text}"
-    return f"****{text[-4:]}"
+    suffix = trimmed[-4:] if len(trimmed) >= 4 else trimmed
+    return f"****{suffix}"
+
+
+def _env(source: Optional[Mapping[str, str]], key: str, default: Optional[str] = None) -> Optional[str]:
+    if source is None:
+        return os.getenv(key, default) if default is not None else os.getenv(key)
+    return source.get(key, default)
 
 
 @dataclass(slots=True)
 class LLMSettings:
-    model: str = "qwen2.5:7b"
-    model_json: str = ""
-    model_text: str = ""
-    endpoint: str = "http://localhost:11434"
-    base_url: str = "http://localhost:11434"
-    keep_alive: str = "30m"
-    timeout_stream_s: float = 60.0
-    timeout_fallback_s: float = 45.0
-    min_chars: int = 8
-    max_attempts: int = 3
-    num_predict: int = 256
-    temperature: float = 0.3
-    top_p: float = 0.9
-    repeat_penalty: float = 1.1
-    num_ctx: int = 4096
-    fallback_trunc: int = 3500
-    force_non_stream: bool = False
-    keywords_first: bool = True
-    disable_hashtags: bool = False
-    target_lang: str = "en"
-    json_prompt: str | None = None
-    json_mode: bool = False
-    json_transcript_limit: int | None = None
+    model: str
+    model_json: str
+    model_text: str
+    endpoint: str
+    base_url: str
+    keep_alive: str
+    timeout_stream_s: float
+    timeout_fallback_s: float
+    min_chars: int
+    max_attempts: int
+    num_predict: int
+    temperature: float
+    top_p: float
+    repeat_penalty: float
+    num_ctx: int
+    fallback_trunc: int
+    force_non_stream: bool
+    keywords_first: bool
+    disable_hashtags: bool
+    target_lang: str
+    json_prompt: Optional[str]
+    json_mode: bool
+    json_transcript_limit: Optional[int]
 
     @property
     def effective_json_model(self) -> str:
@@ -111,6 +146,17 @@ class LLMSettings:
 
 
 @dataclass(slots=True)
+class FetchSettings:
+    timeout_s: float
+    max_per_keyword: int
+    allow_images: bool
+    allow_videos: bool
+    providers: List[str]
+    provider_limits: Dict[str, int]
+    api_keys: Dict[str, Optional[str]]
+
+
+@dataclass(slots=True)
 class BrollSettings:
     min_start_s: float = 2.0
     min_gap_s: float = 1.5
@@ -118,39 +164,20 @@ class BrollSettings:
 
 
 @dataclass(slots=True)
-class FetchSettings:
-    max_per_keyword: int = 8
-    allow_images: bool = True
-    allow_videos: bool = True
-    providers: tuple[str, ...] = ("pixabay",)
-    provider_limits: dict[str, int] = field(default_factory=dict)
-    timeout_s: float = 8.0
-    api_keys: dict[str, str | None] = field(default_factory=dict)
-
-
-@dataclass(slots=True)
-class LogSettings:
-    logger_name: str = "video_pipeline.config"
-    startup_label: str = "[CONFIG]"
-    masked_env_keys: tuple[str, ...] = (
-        "PEXELS_API_KEY",
-        "PIXABAY_API_KEY",
-        "UNSPLASH_ACCESS_KEY",
-    )
-
-
-@dataclass(slots=True)
 class Settings:
     clips_dir: Path
     output_dir: Path
     temp_dir: Path
+    tfidf_fallback_disabled: bool
+    llm_max_queries_per_segment: int
+    fast_tests: bool
+    max_segments_in_flight: int
     llm: LLMSettings
-    broll: BrollSettings
     fetch: FetchSettings
-    log: LogSettings = field(default_factory=LogSettings)
+    broll: BrollSettings
 
-    def to_log_payload(self) -> dict[str, object]:
-        payload: dict[str, object] = {
+    def to_log_payload(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {
             "paths": {
                 "clips_dir": str(self.clips_dir),
                 "output_dir": str(self.output_dir),
@@ -166,157 +193,351 @@ class Settings:
                 "timeout_fallback_s": self.llm.timeout_fallback_s,
                 "min_chars": self.llm.min_chars,
                 "max_attempts": self.llm.max_attempts,
+                "num_predict": self.llm.num_predict,
+                "temperature": self.llm.temperature,
+                "top_p": self.llm.top_p,
+                "repeat_penalty": self.llm.repeat_penalty,
+                "num_ctx": self.llm.num_ctx,
+                "fallback_trunc": self.llm.fallback_trunc,
+                "force_non_stream": self.llm.force_non_stream,
+                "keywords_first": self.llm.keywords_first,
+                "disable_hashtags": self.llm.disable_hashtags,
+                "target_lang": self.llm.target_lang,
+                "json_mode": self.llm.json_mode,
+                "json_transcript_limit": self.llm.json_transcript_limit,
+            },
+            "fetch": {
+                "timeout_s": self.fetch.timeout_s,
+                "max_per_keyword": self.fetch.max_per_keyword,
+                "allow_images": self.fetch.allow_images,
+                "allow_videos": self.fetch.allow_videos,
+                "providers": list(self.fetch.providers),
+                "provider_limits": dict(self.fetch.provider_limits),
             },
             "broll": {
                 "min_start_s": self.broll.min_start_s,
                 "min_gap_s": self.broll.min_gap_s,
                 "no_repeat_s": self.broll.no_repeat_s,
             },
-            "fetch": {
-                "max_per_keyword": self.fetch.max_per_keyword,
-                "allow_images": self.fetch.allow_images,
-                "allow_videos": self.fetch.allow_videos,
-                "providers": list(self.fetch.providers),
-                "provider_limits": dict(self.fetch.provider_limits),
-                "timeout_s": self.fetch.timeout_s,
+            "flags": {
+                "tfidf_fallback_disabled": self.tfidf_fallback_disabled,
+                "llm_max_queries_per_segment": self.llm_max_queries_per_segment,
+                "fast_tests": self.fast_tests,
+                "max_segments_in_flight": self.max_segments_in_flight,
             },
         }
 
-        masked_keys: dict[str, str | None] = {}
-        for key in self.log.masked_env_keys:
-            masked_keys[key] = mask(self.fetch.api_keys.get(key))
-        if masked_keys:
-            payload["fetch"]["api_keys"] = masked_keys
+        masked: Dict[str, Optional[str]] = {}
+        for key, raw_value in self.fetch.api_keys.items():
+            masked[key] = _mask_secret(raw_value)
+        if masked:
+            payload["fetch"]["api_keys"] = masked
 
         return payload
 
 
-def _get_env(source: Mapping[str, str] | None, key: str, default: str | None = None) -> str | None:
-    if source is None:
-        return os.getenv(key, default) if default is not None else os.getenv(key)
-    return source.get(key, default)
+def _resolve_bool_env(
+    source: Optional[Mapping[str, str]],
+    *keys: str,
+    default: bool = False,
+) -> bool:
+    for key in keys:
+        if not key:
+            continue
+        candidate = _env(source, key)
+        if candidate is not None:
+            return _coerce_bool(candidate, default=default)
+    return bool(default)
 
 
-def load_settings(env: Mapping[str, str] | None = None) -> Settings:
-    """Load :class:`Settings` from the provided mapping or ``os.environ``."""
-    clips_dir = Path(_get_env(env, "PIPELINE_CLIPS_DIR", "clips") or "clips")
-    output_dir = Path(_get_env(env, "PIPELINE_OUTPUT_DIR", "output") or "output")
-    temp_dir = Path(_get_env(env, "PIPELINE_TEMP_DIR", "temp") or "temp")
+def _resolve_optional_int(
+    source: Optional[Mapping[str, str]],
+    key: str,
+    *,
+    minimum: int | None = None,
+) -> Optional[int]:
+    value = _env(source, key)
+    if value is None:
+        return None
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+    if minimum is not None and parsed < minimum:
+        parsed = minimum
+    return parsed
 
-    llm_model = _clean(_get_env(env, "PIPELINE_LLM_MODEL", "qwen2.5:7b") or "qwen2.5:7b")
-    llm_model_json = _clean(_get_env(env, "PIPELINE_LLM_MODEL_JSON", "") or "")
-    llm_model_text = _clean(_get_env(env, "PIPELINE_LLM_MODEL_TEXT", "") or "")
-    llm_endpoint = _clean(
-        _get_env(env, "PIPELINE_LLM_ENDPOINT")
-        or _get_env(env, "PIPELINE_LLM_BASE_URL")
+
+def _tfidf_disabled(source: Optional[Mapping[str, str]]) -> bool:
+    flag = _resolve_bool_env(
+        source,
+        "PIPELINE_TFIDF_FALLBACK_DISABLED",
+        "PIPELINE_DISABLE_TFIDF_FALLBACK",
+        default=False,
+    )
+    return bool(flag)
+
+
+def _llm_settings(env: Optional[Mapping[str, str]]) -> LLMSettings:
+    model = _clean_text(_env(env, "PIPELINE_LLM_MODEL", "qwen2.5:7b") or "qwen2.5:7b")
+    model_json = _clean_text(_env(env, "PIPELINE_LLM_MODEL_JSON", "") or "")
+    model_text = _clean_text(_env(env, "PIPELINE_LLM_MODEL_TEXT", "") or "")
+    endpoint = _clean_text(
+        _env(env, "PIPELINE_LLM_ENDPOINT")
+        or _env(env, "PIPELINE_LLM_BASE_URL")
         or "http://localhost:11434"
     )
-    llm_keep_alive = _clean(_get_env(env, "PIPELINE_LLM_KEEP_ALIVE", "30m") or "30m")
-    llm_timeout_stream = to_float(_get_env(env, "PIPELINE_LLM_TIMEOUT_S", "60"), 60.0)
-    llm_timeout_fallback = to_float(_get_env(env, "PIPELINE_LLM_FALLBACK_TIMEOUT_S", "45"), 45.0)
-    llm_min_chars = to_int(_get_env(env, "PIPELINE_LLM_MIN_CHARS", "8"), 8)
-    llm_max_attempts = to_int(_get_env(env, "PIPELINE_LLM_MAX_ATTEMPTS", "3"), 3)
-    llm_num_predict = to_int(_get_env(env, "PIPELINE_LLM_NUM_PREDICT", "256"), 256)
-    llm_temperature = to_float(_get_env(env, "PIPELINE_LLM_TEMP", "0.3"), 0.3)
-    llm_top_p = to_float(_get_env(env, "PIPELINE_LLM_TOP_P", "0.9"), 0.9)
-    llm_repeat_penalty = to_float(_get_env(env, "PIPELINE_LLM_REPEAT_PENALTY", "1.1"), 1.1)
-    llm_num_ctx = to_int(_get_env(env, "PIPELINE_LLM_NUM_CTX", "4096"), 4096)
-    llm_fallback_trunc = to_int(_get_env(env, "PIPELINE_LLM_FALLBACK_TRUNC", "3500"), 3500)
-    llm_force_non_stream = to_bool(_get_env(env, "PIPELINE_LLM_FORCE_NON_STREAM"), False)
-    llm_keywords_first = to_bool(_get_env(env, "PIPELINE_LLM_KEYWORDS_FIRST"), True)
-    llm_disable_hashtags = to_bool(_get_env(env, "PIPELINE_LLM_DISABLE_HASHTAGS"), False)
-    llm_target_lang = _clean(_get_env(env, "PIPELINE_LLM_TARGET_LANG", "en") or "en")
-    llm_json_prompt = _clean(_get_env(env, "PIPELINE_LLM_JSON_PROMPT") or "") or None
-    llm_json_mode = to_bool(_get_env(env, "PIPELINE_LLM_JSON_MODE"), False)
-    llm_json_transcript_limit_raw = _clean(_get_env(env, "PIPELINE_LLM_JSON_TRANSCRIPT_LIMIT") or "")
-    llm_json_transcript_limit = None
-    if llm_json_transcript_limit_raw:
-        llm_json_transcript_limit = to_int(llm_json_transcript_limit_raw, 0)
+    keep_alive = _clean_text(_env(env, "PIPELINE_LLM_KEEP_ALIVE", "30m") or "30m")
+    timeout_stream_s = _coerce_float(
+        _env(env, "PIPELINE_LLM_TIMEOUT_S", "60"),
+        60.0,
+        minimum=0.0,
+    )
+    timeout_fallback_s = _coerce_float(
+        _env(env, "PIPELINE_LLM_FALLBACK_TIMEOUT_S", "45"),
+        45.0,
+        minimum=0.0,
+    )
+    min_chars = _coerce_int(
+        _env(env, "PIPELINE_LLM_MIN_CHARS", "8"),
+        8,
+        minimum=0,
+    )
+    max_attempts = _coerce_int(
+        _env(env, "PIPELINE_LLM_MAX_ATTEMPTS", "3"),
+        3,
+        minimum=1,
+    )
+    num_predict = _coerce_int(
+        _env(env, "PIPELINE_LLM_NUM_PREDICT", "256"),
+        256,
+        minimum=1,
+    )
+    temperature = _coerce_float(
+        _env(env, "PIPELINE_LLM_TEMP", "0.3"),
+        0.3,
+        minimum=0.0,
+    )
+    top_p = _coerce_float(
+        _env(env, "PIPELINE_LLM_TOP_P", "0.9"),
+        0.9,
+        minimum=0.0,
+    )
+    repeat_penalty = _coerce_float(
+        _env(env, "PIPELINE_LLM_REPEAT_PENALTY", "1.1"),
+        1.1,
+        minimum=0.0,
+    )
+    num_ctx = _coerce_int(
+        _env(env, "PIPELINE_LLM_NUM_CTX", "4096"),
+        4096,
+        minimum=1,
+    )
+    fallback_trunc = _coerce_int(
+        _env(env, "PIPELINE_LLM_FALLBACK_TRUNC", "3500"),
+        3500,
+        minimum=0,
+    )
+    force_non_stream = _resolve_bool_env(
+        env,
+        "PIPELINE_LLM_FORCE_NON_STREAM",
+        default=False,
+    )
+    keywords_first = _resolve_bool_env(
+        env,
+        "PIPELINE_LLM_KEYWORDS_FIRST",
+        default=True,
+    )
+    disable_hashtags = _resolve_bool_env(
+        env,
+        "PIPELINE_LLM_DISABLE_HASHTAGS",
+        default=False,
+    )
+    target_lang = _clean_text(_env(env, "PIPELINE_LLM_TARGET_LANG", "en") or "en")
+    json_prompt = _clean_text(_env(env, "PIPELINE_LLM_JSON_PROMPT") or "") or None
+    json_mode = _resolve_bool_env(
+        env,
+        "PIPELINE_LLM_JSON_MODE",
+        default=False,
+    )
+    json_transcript_limit_raw = _env(env, "PIPELINE_LLM_JSON_TRANSCRIPT_LIMIT")
+    json_transcript_limit: Optional[int]
+    if json_transcript_limit_raw:
+        json_transcript_limit = _coerce_int(
+            json_transcript_limit_raw,
+            0,
+            minimum=0,
+        )
+    else:
+        json_transcript_limit = None
 
-    llm_settings = LLMSettings(
-        model=llm_model,
-        model_json=llm_model_json,
-        model_text=llm_model_text,
-        endpoint=llm_endpoint,
-        base_url=llm_endpoint,
-        keep_alive=llm_keep_alive,
-        timeout_stream_s=llm_timeout_stream,
-        timeout_fallback_s=llm_timeout_fallback,
-        min_chars=llm_min_chars,
-        max_attempts=llm_max_attempts,
-        num_predict=llm_num_predict,
-        temperature=llm_temperature,
-        top_p=llm_top_p,
-        repeat_penalty=llm_repeat_penalty,
-        num_ctx=llm_num_ctx,
-        fallback_trunc=llm_fallback_trunc,
-        force_non_stream=llm_force_non_stream,
-        keywords_first=llm_keywords_first,
-        disable_hashtags=llm_disable_hashtags,
-        target_lang=llm_target_lang,
-        json_prompt=llm_json_prompt,
-        json_mode=llm_json_mode,
-        json_transcript_limit=llm_json_transcript_limit,
+    return LLMSettings(
+        model=model,
+        model_json=model_json,
+        model_text=model_text,
+        endpoint=endpoint,
+        base_url=endpoint,
+        keep_alive=keep_alive,
+        timeout_stream_s=timeout_stream_s,
+        timeout_fallback_s=timeout_fallback_s,
+        min_chars=min_chars,
+        max_attempts=max_attempts,
+        num_predict=num_predict,
+        temperature=temperature,
+        top_p=top_p,
+        repeat_penalty=repeat_penalty,
+        num_ctx=num_ctx,
+        fallback_trunc=fallback_trunc,
+        force_non_stream=force_non_stream,
+        keywords_first=keywords_first,
+        disable_hashtags=disable_hashtags,
+        target_lang=target_lang,
+        json_prompt=json_prompt,
+        json_mode=json_mode,
+        json_transcript_limit=json_transcript_limit,
     )
 
-    broll_settings = BrollSettings(
-        min_start_s=to_float(_get_env(env, "PIPELINE_BROLL_MIN_START_SECONDS", "2.0"), 2.0),
-        min_gap_s=to_float(_get_env(env, "PIPELINE_BROLL_MIN_GAP_SECONDS", "1.5"), 1.5),
-        no_repeat_s=to_float(_get_env(env, "PIPELINE_BROLL_NO_REPEAT_SECONDS", "6.0"), 6.0),
+
+def _broll_settings(env: Optional[Mapping[str, str]]) -> BrollSettings:
+    return BrollSettings(
+        min_start_s=_coerce_float(
+            _env(env, "PIPELINE_BROLL_MIN_START_SECONDS", "2.0"),
+            2.0,
+            minimum=0.0,
+        ),
+        min_gap_s=_coerce_float(
+            _env(env, "PIPELINE_BROLL_MIN_GAP_SECONDS", "1.5"),
+            1.5,
+            minimum=0.0,
+        ),
+        no_repeat_s=_coerce_float(
+            _env(env, "PIPELINE_BROLL_NO_REPEAT_SECONDS", "6.0"),
+            6.0,
+            minimum=0.0,
+        ),
     )
 
-    provider_values = csv_list(
-        _get_env(env, "BROLL_FETCH_PROVIDER")
-        or _get_env(env, "AI_BROLL_FETCH_PROVIDER")
-    )
-    if not provider_values:
-        provider_values = ["pixabay"]
 
-    provider_limits: dict[str, int] = {}
-    for provider in provider_values:
-        env_key = f"BROLL_{provider.upper()}_MAX_PER_KEYWORD"
-        limit = _get_env(env, env_key)
+def _fetch_settings(env: Optional[Mapping[str, str]]) -> FetchSettings:
+    providers = _split_csv(
+        _env(env, "BROLL_FETCH_PROVIDER")
+        or _env(env, "AI_BROLL_FETCH_PROVIDER")
+    )
+    if not providers:
+        providers = ["pixabay"]
+
+    provider_limits: Dict[str, int] = {}
+    for provider in providers:
+        key = f"BROLL_{provider.upper()}_MAX_PER_KEYWORD"
+        limit = _resolve_optional_int(env, key, minimum=1)
         if limit is not None:
-            provider_limits[provider.lower()] = to_int(limit, 1)
+            provider_limits[provider] = limit
 
-    fetch_timeout = to_float(_get_env(env, "PIPELINE_FETCH_TIMEOUT_S", "8"), 8.0)
-    fetch_max_default = to_int(_get_env(env, "FETCH_MAX", "8"), 8)
-    fetch_max_per_keyword = to_int(
-        _get_env(env, "BROLL_FETCH_MAX_PER_KEYWORD"),
-        fetch_max_default,
+    timeout_s = _coerce_float(
+        _env(env, "PIPELINE_FETCH_TIMEOUT_S", "8"),
+        8.0,
+        minimum=0.0,
     )
+    default_max = _coerce_int(
+        _env(env, "FETCH_MAX", "8"),
+        8,
+        minimum=1,
+    )
+    max_per_keyword = _coerce_int(
+        _env(env, "BROLL_FETCH_MAX_PER_KEYWORD"),
+        default_max,
+        minimum=1,
+    )
+    allow_images = _resolve_bool_env(env, "BROLL_FETCH_ALLOW_IMAGES", default=True)
+    allow_videos = _resolve_bool_env(env, "BROLL_FETCH_ALLOW_VIDEOS", default=True)
 
-    fetch_settings = FetchSettings(
-        max_per_keyword=fetch_max_per_keyword,
-        allow_images=to_bool(_get_env(env, "BROLL_FETCH_ALLOW_IMAGES"), True),
-        allow_videos=to_bool(_get_env(env, "BROLL_FETCH_ALLOW_VIDEOS"), True),
-        providers=tuple(p.lower() for p in provider_values),
+    api_keys: Dict[str, Optional[str]] = {
+        "PEXELS_API_KEY": _env(env, "PEXELS_API_KEY"),
+        "PIXABAY_API_KEY": _env(env, "PIXABAY_API_KEY"),
+        "UNSPLASH_ACCESS_KEY": _env(env, "UNSPLASH_ACCESS_KEY"),
+    }
+
+    return FetchSettings(
+        timeout_s=timeout_s,
+        max_per_keyword=max_per_keyword,
+        allow_images=allow_images,
+        allow_videos=allow_videos,
+        providers=providers,
         provider_limits=provider_limits,
-        timeout_s=fetch_timeout,
-        api_keys={
-            "PEXELS_API_KEY": _get_env(env, "PEXELS_API_KEY"),
-            "PIXABAY_API_KEY": _get_env(env, "PIXABAY_API_KEY"),
-            "UNSPLASH_ACCESS_KEY": _get_env(env, "UNSPLASH_ACCESS_KEY"),
-        },
+        api_keys=api_keys,
     )
 
-    log_settings = LogSettings()
+
+def load_settings(env: Optional[Mapping[str, str]] = None) -> Settings:
+    clips_dir = Path(_env(env, "PIPELINE_CLIPS_DIR", "clips") or "clips")
+    output_dir = Path(_env(env, "PIPELINE_OUTPUT_DIR", "output") or "output")
+    temp_dir = Path(_env(env, "PIPELINE_TEMP_DIR", "temp") or "temp")
+
+    llm = _llm_settings(env)
+    fetch = _fetch_settings(env)
+    broll = _broll_settings(env)
+
+    tfidf_disabled = _tfidf_disabled(env)
+    llm_queries = _coerce_int(
+        _env(env, "PIPELINE_LLM_MAX_QUERIES_PER_SEGMENT"),
+        3,
+        minimum=1,
+    )
+    fast_tests = _resolve_bool_env(env, "PIPELINE_FAST_TESTS", default=False)
+    max_segments_in_flight = _coerce_int(
+        _env(env, "PIPELINE_MAX_SEGMENTS_IN_FLIGHT"),
+        1,
+        minimum=1,
+    )
 
     return Settings(
         clips_dir=clips_dir,
         output_dir=output_dir,
         temp_dir=temp_dir,
-        llm=llm_settings,
-        broll=broll_settings,
-        fetch=fetch_settings,
-        log=log_settings,
+        tfidf_fallback_disabled=tfidf_disabled,
+        llm_max_queries_per_segment=llm_queries,
+        fast_tests=fast_tests,
+        max_segments_in_flight=max_segments_in_flight,
+        llm=llm,
+        fetch=fetch,
+        broll=broll,
     )
 
 
-def log_effective_settings(settings: Settings, logger: logging.Logger | None = None) -> None:
-    """Emit a single startup log describing the effective configuration."""
-    logger = logger or logging.getLogger(settings.log.logger_name)
+def set_settings(settings: Settings) -> None:
+    global _SETTINGS_CACHE
+    with _CACHE_LOCK:
+        _SETTINGS_CACHE = settings
+
+
+def get_settings() -> Settings:
+    global _SETTINGS_CACHE
+    with _CACHE_LOCK:
+        if _SETTINGS_CACHE is None:
+            _SETTINGS_CACHE = load_settings()
+        return _SETTINGS_CACHE
+
+
+def log_effective_settings(settings: Settings, logger: Optional[logging.Logger] = None) -> None:
+    global _STARTUP_LOG_EMITTED
+    with _CACHE_LOCK:
+        if _STARTUP_LOG_EMITTED:
+            return
+        _STARTUP_LOG_EMITTED = True
+    logger = logger or logging.getLogger("video_pipeline.config")
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+        logger.propagate = False
     payload = settings.to_log_payload()
-    message = f"{settings.log.startup_label} effective={json.dumps(payload, sort_keys=True)}"
+    message = f"[CONFIG] effective={json.dumps(payload, sort_keys=True, ensure_ascii=True)}"
     logger.info(message)
+
+
+def reset_startup_log_for_tests() -> None:
+    global _STARTUP_LOG_EMITTED
+    with _CACHE_LOCK:
+        _STARTUP_LOG_EMITTED = False
 


### PR DESCRIPTION
## Summary
- restore the typed configuration dataclasses with process-wide caching, numeric clamps, and a single `[CONFIG]` log emission
- wire run_pipeline and the legacy config.py shim to the shared settings API and re-export the helpers from video_pipeline.config
- refresh the config bootstrap tests and document the resolved Lot 1 merge in AUDIT.md

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONUTF8=1 pytest -q --capture=sys tests/test_config_boot.py
- python -c "from video_pipeline.config import load_settings, log_effective_settings, reset_startup_log_for_tests; reset_startup_log_for_tests(); s=load_settings(); log_effective_settings(s); log_effective_settings(s)"


------
https://chatgpt.com/codex/tasks/task_e_68e3df7c48748330a629a7ba0ce9549d