### PR TITLE
Add B-roll schedule invariants and tests

### DIFF
--- a/src/video_pipeline/broll_rules.py
+++ b/src/video_pipeline/broll_rules.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import List, Dict
+
+
+@dataclass(frozen=True)
+class BrollClip:
+    start_s: float
+    end_s: float
+    asset_id: str
+    segment_index: int
+
+
+def _duration(c: BrollClip) -> float:
+    return max(0.0, c.end_s - c.start_s)
+
+
+def enforce_broll_schedule_rules(
+    clips: List[BrollClip],
+    *,
+    min_start_s: float,
+    min_gap_s: float,
+    no_repeat_s: float
+) -> List[BrollClip]:
+    """
+    Applique 3 invariants:
+      1) Aucun B-roll avant `min_start_s`
+      2) Espace minimal `min_gap_s` entre la fin du précédent et le début du suivant
+      3) Anti-répétition: même asset interdit dans une fenêtre `no_repeat_s`
+    Stratégie: tri par (start, duration), filtrage en un passage.
+    """
+    if not clips:
+        return []
+
+    # Normalisation/tri déterministe
+    clips = [
+        BrollClip(
+            start_s=max(0.0, float(c.start_s)),
+            end_s=max(float(c.start_s), float(c.end_s)),
+            asset_id=str(c.asset_id),
+            segment_index=int(c.segment_index),
+        )
+        for c in clips
+    ]
+    clips.sort(key=lambda c: (c.start_s, _duration(c)))
+
+    kept: List[BrollClip] = []
+    last_end: float = float("-inf")
+    last_by_asset: Dict[str, float] = {}
+
+    for c in clips:
+        # (1) Hook initial
+        if c.start_s < float(min_start_s):
+            continue
+
+        # (2) Gap minimal
+        if kept and (c.start_s - last_end) < float(min_gap_s):
+            continue
+
+        # (3) Anti-repeat sur fenêtre temporelle
+        prev_t = last_by_asset.get(c.asset_id)
+        if prev_t is not None and (c.start_s - prev_t) < float(no_repeat_s):
+            continue
+
+        kept.append(c)
+        last_end = c.end_s
+        last_by_asset[c.asset_id] = c.start_s
+
+    return kept

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,10 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
+SRC_DIR = ROOT_DIR / "src"
+if SRC_DIR.exists() and str(SRC_DIR) not in sys.path:
+    sys.path.insert(1, str(SRC_DIR))
+
 import os
 
 os.environ.setdefault("PIPELINE_FAST_TESTS", "1")

--- a/tests/test_broll_invariants.py
+++ b/tests/test_broll_invariants.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from test_duration_gap_rules import _load_video_processor
 from video_pipeline.broll_rules import BrollClip, enforce_broll_schedule_rules
 
 
@@ -50,3 +54,69 @@ def test_stable_sort_and_duration_guard():
         no_repeat_s=0.0,
     )
     assert [c.asset_id for c in out] == ["b:short", "c:ok"]
+
+
+def test_core_pipeline_integration_applies_invariants(monkeypatch):
+    vp = _load_video_processor()
+
+    dummy_settings = SimpleNamespace(
+        broll=SimpleNamespace(min_start_s=2.0, min_gap_s=1.5, no_repeat_s=6.0)
+    )
+    monkeypatch.setattr(vp, "get_settings", lambda: dummy_settings, raising=False)
+
+    entries = [
+        vp.CoreTimelineEntry(
+            path=Path("clip_hook.mp4"),
+            start=0.5,
+            end=1.4,
+            segment_index=0,
+            url="asset:hook",
+        ),
+        vp.CoreTimelineEntry(
+            path=Path("clip_one.mp4"),
+            start=2.0,
+            end=3.0,
+            segment_index=1,
+            url="asset:repeat",
+        ),
+        vp.CoreTimelineEntry(
+            path=Path("clip_gap.mp4"),
+            start=3.1,
+            end=4.0,
+            segment_index=2,
+            url="asset:gap",
+        ),
+        vp.CoreTimelineEntry(
+            path=Path("clip_two.mp4"),
+            start=4.7,
+            end=5.4,
+            segment_index=3,
+            url="asset:unique",
+        ),
+        vp.CoreTimelineEntry(
+            path=Path("clip_three.mp4"),
+            start=11.2,
+            end=12.0,
+            segment_index=4,
+            url="asset:repeat",
+        ),
+    ]
+
+    updates = [{"url": entry.url} for entry in entries]
+
+    filtered_entries, filtered_updates = vp._apply_broll_invariants_to_core_entries(
+        entries,
+        seen_updates=updates,
+    )
+
+    assert [entry.url for entry in filtered_entries] == [
+        "asset:repeat",
+        "asset:unique",
+        "asset:repeat",
+    ]
+    assert filtered_updates is not None
+    assert [update["url"] for update in filtered_updates] == [
+        "asset:repeat",
+        "asset:unique",
+        "asset:repeat",
+    ]

--- a/tests/test_broll_invariants.py
+++ b/tests/test_broll_invariants.py
@@ -1,0 +1,53 @@
+import math
+from video_pipeline.broll_rules import BrollClip, enforce_broll_schedule_rules
+
+
+def _c(t0, t1, aid, seg):
+    return BrollClip(start_s=t0, end_s=t1, asset_id=aid, segment_index=seg)
+
+
+def test_filters_min_start_and_gap():
+    clips = [
+        _c(0.5, 1.5, "pexels:1", 0),
+        _c(2.0, 3.0, "pexels:2", 1),
+        _c(3.2, 4.0, "pexels:3", 2),
+        _c(4.6, 5.4, "pexels:4", 3),
+    ]
+    out = enforce_broll_schedule_rules(
+        clips,
+        min_start_s=2.0,
+        min_gap_s=1.5,
+        no_repeat_s=6.0,
+    )
+    assert [(c.asset_id, c.start_s) for c in out] == [("pexels:2", 2.0), ("pexels:4", 4.6)]
+
+
+def test_anti_repeat_window():
+    clips = [
+        _c(2.0, 3.0, "pixabay:42", 0),
+        _c(6.9, 7.5, "pixabay:42", 1),
+        _c(8.1, 9.0, "pixabay:99", 2),
+        _c(9.0, 9.8, "pixabay:42", 3),
+    ]
+    out = enforce_broll_schedule_rules(
+        clips,
+        min_start_s=0.0,
+        min_gap_s=0.0,
+        no_repeat_s=6.0,
+    )
+    assert [c.asset_id for c in out] == ["pixabay:42", "pixabay:99", "pixabay:42"]
+
+
+def test_stable_sort_and_duration_guard():
+    clips = [
+        _c(2.0, 4.0, "a:long", 0),
+        _c(2.0, 2.5, "b:short", 1),
+        _c(4.6, 5.0, "c:ok", 2),
+    ]
+    out = enforce_broll_schedule_rules(
+        clips,
+        min_start_s=0.0,
+        min_gap_s=1.5,
+        no_repeat_s=0.0,
+    )
+    assert [c.asset_id for c in out] == ["b:short", "c:ok"]

--- a/tests/test_broll_invariants.py
+++ b/tests/test_broll_invariants.py
@@ -1,4 +1,3 @@
-import math
 from video_pipeline.broll_rules import BrollClip, enforce_broll_schedule_rules
 
 

--- a/tests/test_duration_gap_rules.py
+++ b/tests/test_duration_gap_rules.py
@@ -25,6 +25,8 @@ def _load_video_processor():
     sys.modules['cv2'] = cv2_module
 
     moviepy_module = ModuleType('moviepy')
+    moviepy_module.__spec__ = machinery.ModuleSpec('moviepy', loader=None, is_package=True)
+    moviepy_module.__path__ = []  # type: ignore[attr-defined]
     editor_module = ModuleType('moviepy.editor')
 
     class _FakeClip:
@@ -49,6 +51,21 @@ def _load_video_processor():
     moviepy_module.editor = editor_module
     sys.modules['moviepy'] = moviepy_module
     sys.modules['moviepy.editor'] = editor_module
+    video_package = ModuleType('moviepy.video')
+    video_package.__spec__ = machinery.ModuleSpec('moviepy.video', loader=None, is_package=True)
+    video_package.__path__ = []  # type: ignore[attr-defined]
+    fx_package = ModuleType('moviepy.video.fx')
+    fx_package.__spec__ = machinery.ModuleSpec('moviepy.video.fx', loader=None, is_package=True)
+    fx_package.__path__ = []  # type: ignore[attr-defined]
+    fx_all_module = ModuleType('moviepy.video.fx.all')
+
+    def _crop_stub(clip, *args, **kwargs):
+        return clip
+
+    fx_all_module.crop = _crop_stub
+    sys.modules['moviepy.video'] = video_package
+    sys.modules['moviepy.video.fx'] = fx_package
+    sys.modules['moviepy.video.fx.all'] = fx_all_module
     moviepy_config = ModuleType('moviepy.config')
     moviepy_config.IMAGEMAGICK_BINARY = None
     sys.modules['moviepy.config'] = moviepy_config

--- a/video_processor.py
+++ b/video_processor.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 # ensure project-root is first
 PROJECT_ROOT = Path(__file__).resolve().parent
 sys.path.insert(0, str(PROJECT_ROOT))
+sys.path.insert(1, str(PROJECT_ROOT / 'src'))
 sys.path.insert(1, str(PROJECT_ROOT / 'AI-B-roll'))
 sys.path.insert(2, str(PROJECT_ROOT / 'AI-B-roll' / 'src'))
 
@@ -21,6 +22,12 @@ from pathlib import Path
 from typing import List, Dict, Any, Optional, Union, Sequence, Set, Tuple, TextIO
 from collections import Counter
 from dataclasses import dataclass
+
+from video_pipeline.broll_rules import (
+    BrollClip,
+    enforce_broll_schedule_rules as apply_broll_schedule_rules,
+)
+from video_pipeline.config.settings import get_settings
 import types
 import gc
 import re
@@ -344,6 +351,82 @@ class _CoreSegment:
     start: float
     end: float
     text: str
+
+
+def _apply_broll_invariants_to_core_entries(
+    entries: Sequence[CoreTimelineEntry],
+    *,
+    seen_updates: Optional[Sequence[Dict[str, Any]]] = None,
+) -> Tuple[List[CoreTimelineEntry], Optional[List[Dict[str, Any]]]]:
+    """Apply B-roll invariants to the provided core entries and mirror metadata."""
+
+    entries_list = list(entries)
+    updates_list = list(seen_updates) if seen_updates is not None else None
+
+    if updates_list is not None and len(updates_list) < len(entries_list):
+        padding = len(entries_list) - len(updates_list)
+        updates_list.extend({} for _ in range(padding))
+
+    if not entries_list:
+        settings = get_settings()
+        print(
+            f"[BROLL_RULES] kept=0/0 (100.0%) min_start={settings.broll.min_start_s}s "
+            f"gap={settings.broll.min_gap_s}s no_repeat={settings.broll.no_repeat_s}s"
+        )
+        return [], [] if updates_list is not None else None
+
+    settings = get_settings()
+
+    clip_records: List[Tuple[CoreTimelineEntry, BrollClip]] = []
+    for entry in entries_list:
+        asset_identifier = entry.url or str(entry.path)
+        clip_records.append(
+            (
+                entry,
+                BrollClip(
+                    start_s=float(entry.start),
+                    end_s=float(entry.end),
+                    asset_id=str(asset_identifier),
+                    segment_index=int(entry.segment_index),
+                ),
+            )
+        )
+
+    filtered_clips = apply_broll_schedule_rules(
+        [clip for _, clip in clip_records],
+        min_start_s=settings.broll.min_start_s,
+        min_gap_s=settings.broll.min_gap_s,
+        no_repeat_s=settings.broll.no_repeat_s,
+    )
+
+    key_counts: Counter[Tuple[float, float, str, int]] = Counter(
+        (clip.start_s, clip.end_s, clip.asset_id, clip.segment_index)
+        for clip in filtered_clips
+    )
+
+    filtered_entries: List[CoreTimelineEntry] = []
+    filtered_updates: Optional[List[Dict[str, Any]]] = [] if updates_list is not None else None
+
+    for idx, (entry, clip) in enumerate(clip_records):
+        key = (clip.start_s, clip.end_s, clip.asset_id, clip.segment_index)
+        if key_counts.get(key, 0):
+            filtered_entries.append(entry)
+            key_counts[key] -= 1
+            if filtered_updates is not None and updates_list is not None and idx < len(updates_list):
+                filtered_updates.append(updates_list[idx])
+
+    total = len(entries_list)
+    kept = len(filtered_entries)
+    ratio = 100.0 if total == 0 else (100.0 * kept / total)
+    print(
+        f"[BROLL_RULES] kept={kept}/{total} ({ratio:.1f}%) "
+        f"min_start={settings.broll.min_start_s}s gap={settings.broll.min_gap_s}s "
+        f"no_repeat={settings.broll.no_repeat_s}s"
+    )
+
+    if filtered_updates is not None:
+        return filtered_entries, filtered_updates
+    return filtered_entries, None
 
 
 def run_with_timeout(fn, timeout_s: float, *args, **kwargs):
@@ -2577,6 +2660,12 @@ class VideoProcessor:
                 )
 
             if timeline_entries:
+                timeline_entries, pending_seen_updates = _apply_broll_invariants_to_core_entries(
+                    timeline_entries,
+                    seen_updates=pending_seen_updates,
+                )
+
+            if timeline_entries:
                 timeline_entries.sort(key=lambda entry: (entry.start, entry.segment_index))
                 self._core_last_timeline = list(timeline_entries)
                 manifest_path: Optional[Path] = None
@@ -3363,6 +3452,9 @@ class VideoProcessor:
                     url=url or None,
                 )
             )
+
+        if timeline_entries:
+            timeline_entries, _ = _apply_broll_invariants_to_core_entries(timeline_entries)
 
         if not timeline_entries:
             return None

--- a/video_processor.py
+++ b/video_processor.py
@@ -23,10 +23,7 @@ from typing import List, Dict, Any, Optional, Union, Sequence, Set, Tuple, TextI
 from collections import Counter
 from dataclasses import dataclass
 
-from video_pipeline.broll_rules import (
-    BrollClip,
-    enforce_broll_schedule_rules as apply_broll_schedule_rules,
-)
+from video_pipeline.broll_rules import BrollClip, enforce_broll_schedule_rules
 from video_pipeline.config.settings import get_settings
 import types
 import gc
@@ -392,7 +389,7 @@ def _apply_broll_invariants_to_core_entries(
             )
         )
 
-    filtered_clips = apply_broll_schedule_rules(
+    filtered_clips = enforce_broll_schedule_rules(
         [clip for _, clip in clip_records],
         min_start_s=settings.broll.min_start_s,
         min_gap_s=settings.broll.min_gap_s,

--- a/video_processor.py
+++ b/video_processor.py
@@ -23,7 +23,7 @@ from typing import List, Dict, Any, Optional, Union, Sequence, Set, Tuple, TextI
 from collections import Counter
 from dataclasses import dataclass
 
-from video_pipeline.broll_rules import BrollClip, enforce_broll_schedule_rules
+from video_pipeline.broll_rules import BrollClip, enforce_broll_schedule_rules as _enforce_broll_schedule_rules_v2
 from video_pipeline.config.settings import get_settings
 import types
 import gc
@@ -389,7 +389,7 @@ def _apply_broll_invariants_to_core_entries(
             )
         )
 
-    filtered_clips = enforce_broll_schedule_rules(
+    filtered_clips = _enforce_broll_schedule_rules_v2(
         [clip for _, clip in clip_records],
         min_start_s=settings.broll.min_start_s,
         min_gap_s=settings.broll.min_gap_s,


### PR DESCRIPTION
## Summary
- add a dedicated `video_pipeline.broll_rules` module that normalizes clips and enforces min-start, gap, and anti-repeat constraints
- integrate the invariants into the core B-roll rendering paths with telemetry logging based on typed settings
- expose the new rules to tests by extending the src path and adding focused acceptance coverage

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD="1" pytest -q --capture=sys tests/test_broll_invariants.py`


------
https://chatgpt.com/codex/tasks/task_e_68e3f61a588483309fc9bd960172c8f5