### PR TITLE
feat: enforce configurable b-roll invariants

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -74,6 +74,16 @@ flowchart LR
 - **B-roll** :
   - Durée minimale par clip (`min_duration` param) et intervalle (`min_gap`) doivent être respectés ; actuellement seules ces règles sont codées et doivent être enrichies (min start, anti-repeat, min gap configurable).【F:video_processor.py†L423-L447】
   - `FetcherOrchestratorConfig.per_segment_limit` plafonne le nombre de candidats retenus, déterminé par env (`BROLL_FETCH_MAX_PER_KEYWORD`).【F:pipeline_core/configuration.py†L320-L431】
+
+### B-roll invariants
+
+La phase d'ordonnancement applique désormais trois invariants configurables via `BrollSettings` (`video_pipeline.config.settings`).【F:video_pipeline/config/settings.py†L160-L234】 Le module `video_pipeline.broll_rules` filtre les clips fournis par les fetchers afin de :
+
+1. Décaler le premier B-roll après `min_start_s` pour préserver le hook.【F:src/video_pipeline/broll_rules.py†L45-L53】
+2. Garantir un intervalle minimal `min_gap_s` entre insertions successives.【F:src/video_pipeline/broll_rules.py†L55-L60】
+3. Éviter toute réutilisation d'un asset dans la fenêtre `no_repeat_s`, en journalisant les exclusions `[BROLL]` correspondantes.【F:src/video_pipeline/broll_rules.py†L62-L72】
+
+Ces règles s'exécutent sans impacter les phases de sélection fournisseur : seules les propositions incompatibles sont écartées, assurant la cohérence entre config typée et planification finale.【F:video_processor.py†L360-L405】
 - **Chemins** :
   - `JsonlLogger` crée le dossier parent avant écriture, garantissant l'idempotence des runs.【F:pipeline_core/logging.py†L34-L118】
   - `run_pipeline.py` garantit UTF-8 et normalise les variables `ENABLE_PIPELINE_CORE_FETCHER`/providers avant lancement.【F:run_pipeline.py†L40-L200】

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,44 @@
+"""Test helpers for constructing deterministic B-roll clips."""
+
+from __future__ import annotations
+
+from typing import List, Sequence, Tuple
+
+from video_pipeline.broll_rules import BrollClip
+
+
+def make_clip(
+    start_s: float,
+    end_s: float,
+    asset_id: str,
+    *,
+    segment_index: int = 0,
+) -> BrollClip:
+    """Create a ``BrollClip`` with explicit typing for tests."""
+
+    return BrollClip(
+        start_s=float(start_s),
+        end_s=float(end_s),
+        asset_id=str(asset_id),
+        segment_index=int(segment_index),
+    )
+
+
+def plan_from_tuples(
+    items: Sequence[Tuple[float, float, str]],
+    *,
+    segment_offset: int = 0,
+) -> List[BrollClip]:
+    """Convert ``(start, end, asset)`` tuples into ``BrollClip`` instances."""
+
+    clips: List[BrollClip] = []
+    for idx, (start_s, end_s, asset_id) in enumerate(items, start=segment_offset):
+        clips.append(
+            make_clip(
+                start_s=start_s,
+                end_s=end_s,
+                asset_id=asset_id,
+                segment_index=idx,
+            )
+        )
+    return clips

--- a/tests/test_broll_min_gap_respected.py
+++ b/tests/test_broll_min_gap_respected.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from tests.factories import plan_from_tuples
+from video_pipeline.broll_rules import enforce_broll_schedule_rules
+
+
+def test_broll_min_gap_respected():
+    clips = plan_from_tuples(
+        [
+            (2.0, 3.0, "segment:a"),
+            (3.2, 4.0, "segment:b"),
+            (4.3, 5.0, "segment:c"),
+            (5.6, 6.4, "segment:d"),
+        ]
+    )
+
+    kept = enforce_broll_schedule_rules(
+        clips,
+        min_start_s=0.0,
+        min_gap_s=1.5,
+        no_repeat_s=0.0,
+    )
+
+    assert [clip.asset_id for clip in kept] == ["segment:a", "segment:d"]
+    for first, second in zip(kept, kept[1:]):
+        assert (second.start_s - first.end_s) >= 1.5 - 1e-6

--- a/tests/test_broll_min_start_respected.py
+++ b/tests/test_broll_min_start_respected.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from tests.factories import plan_from_tuples
+from video_pipeline.broll_rules import enforce_broll_schedule_rules
+
+
+def test_broll_min_start_respected():
+    clips = plan_from_tuples(
+        [
+            (0.5, 1.6, "hook:ignore"),
+            (1.9, 3.0, "hook:still-too-soon"),
+            (2.1, 3.4, "segment:a"),
+            (4.4, 5.2, "segment:b"),
+        ]
+    )
+
+    kept = enforce_broll_schedule_rules(
+        clips,
+        min_start_s=2.0,
+        min_gap_s=0.0,
+        no_repeat_s=0.0,
+    )
+
+    assert [clip.asset_id for clip in kept] == ["segment:a", "segment:b"]
+    assert all(clip.start_s >= 2.0 for clip in kept)

--- a/tests/test_broll_no_repeat_window.py
+++ b/tests/test_broll_no_repeat_window.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from tests.factories import plan_from_tuples
+from video_pipeline.broll_rules import enforce_broll_schedule_rules
+
+
+def test_broll_no_repeat_window():
+    clips = plan_from_tuples(
+        [
+            (2.0, 3.2, "asset:loop"),
+            (6.5, 7.4, "asset:loop"),
+            (8.0, 8.9, "asset:unique"),
+            (11.9, 12.8, "asset:loop"),
+        ]
+    )
+
+    kept = enforce_broll_schedule_rules(
+        clips,
+        min_start_s=0.0,
+        min_gap_s=0.0,
+        no_repeat_s=6.0,
+    )
+
+    assert [clip.asset_id for clip in kept] == [
+        "asset:loop",
+        "asset:unique",
+        "asset:loop",
+    ]
+    assert kept[1].start_s - kept[0].start_s >= 6.0


### PR DESCRIPTION
## Summary
- enforce the min_start, min_gap, and no_repeat invariants in the B-roll scheduler with explicit logging
- document the new B-roll invariants and add factories to build deterministic clip plans in tests
- add acceptance tests covering min start, minimum gap, and anti-repeat windows

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest --capture=sys tests/test_broll_min_start_respected.py tests/test_broll_min_gap_respected.py tests/test_broll_no_repeat_window.py

------
https://chatgpt.com/codex/tasks/task_e_68e4266be4a883308e39a9a286ac51c6