### PR TITLE
Add metadata-first segment mode and persist streaming fallback

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -393,6 +393,17 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     settings = get_settings()
     log_effective_settings(settings)
 
+    if settings.llm.force_non_stream:
+        os.environ["PIPELINE_LLM_FORCE_NON_STREAM"] = "1"
+    else:
+        os.environ.setdefault("PIPELINE_LLM_FORCE_NON_STREAM", "0")
+
+    timeout_value = max(5, int(settings.llm.timeout_fallback_s)) if settings.llm.timeout_fallback_s else 35
+    os.environ.setdefault("PIPELINE_LLM_TIMEOUT_S", str(timeout_value))
+
+    num_predict_value = max(1, int(settings.llm.num_predict)) if settings.llm.num_predict else 96
+    os.environ.setdefault("PIPELINE_LLM_NUM_PREDICT", str(min(96, num_predict_value)))
+
     parser = argparse.ArgumentParser(
         description="Launch the video pipeline with stable environment defaults."
     )

--- a/tests/test_llm_segment_blocking.py
+++ b/tests/test_llm_segment_blocking.py
@@ -1,0 +1,30 @@
+import os
+
+import pipeline_core.llm_service as llm_module
+from pipeline_core.llm_service import LLMMetadataGeneratorService
+
+
+def test_llm_segment_blocking(monkeypatch):
+    monkeypatch.setenv("PIPELINE_FAST_TESTS", "1")
+    monkeypatch.setenv("PIPELINE_LLM_FORCE_NON_STREAM", "1")
+    llm_module._reset_stream_state_for_tests()
+
+    calls = {"sync": 0}
+
+    def fake_sync(endpoint, model, prompt, options):
+        calls["sync"] += 1
+        return "non_stream_payload"
+
+    monkeypatch.setattr(llm_module, "_ollama_generate_sync", fake_sync)
+
+    service = LLMMetadataGeneratorService(reuse_shared=False)
+    text, reason, chunk_count = service._complete_text("hello", max_tokens=16, purpose="dynamic")
+
+    assert text == "non_stream_payload"
+    assert reason == ""
+    assert chunk_count == 0
+    assert calls["sync"] == 1
+
+    path_mode, path_reason = llm_module._current_llm_path()
+    assert path_mode == "segment_blocking"
+    assert path_reason == "flag_disable"

--- a/tests/test_llm_stream_fallback_once.py
+++ b/tests/test_llm_stream_fallback_once.py
@@ -1,0 +1,64 @@
+import json
+
+import pipeline_core.llm_service as llm_module
+from pipeline_core.llm_service import LLMMetadataGeneratorService
+
+
+def test_llm_stream_fallback_once(monkeypatch):
+    monkeypatch.setenv("PIPELINE_FAST_TESTS", "1")
+    monkeypatch.delenv("PIPELINE_LLM_FORCE_NON_STREAM", raising=False)
+    llm_module._reset_stream_state_for_tests()
+
+    error_line = "data: " + json.dumps({"error": "boom"})
+    ok_line = "data: " + json.dumps({"response": "stream text"})
+    done_line = "data: " + json.dumps({"done": True})
+
+    class DummyResponse:
+        def __init__(self, lines):
+            self._lines = lines
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        def iter_lines(self, decode_unicode=True):
+            for line in self._lines:
+                yield line
+
+    calls = {"stream": 0, "sync": 0}
+
+    def fake_post(*_args, **_kwargs):
+        calls["stream"] += 1
+        if calls["stream"] == 1:
+            return DummyResponse([error_line])
+        return DummyResponse([ok_line, done_line])
+
+    def fake_sync(endpoint, model, prompt, options):
+        calls["sync"] += 1
+        return f"blocking-{calls['sync']}"
+
+    monkeypatch.setattr(llm_module.requests, "post", fake_post)
+    monkeypatch.setattr(llm_module, "_ollama_generate_sync", fake_sync)
+
+    service = LLMMetadataGeneratorService(reuse_shared=False)
+
+    text1, reason1, chunk1 = service._complete_text("hello", max_tokens=32, purpose="dynamic")
+    assert text1.startswith("blocking-1")
+    assert reason1 in {"", "stream_err", "timeout"} or reason1.startswith("error:")
+    assert calls["stream"] == 1
+    assert calls["sync"] == 1
+
+    text2, reason2, chunk2 = service._complete_text("second", max_tokens=32, purpose="dynamic")
+    assert text2.startswith("blocking-2")
+    assert reason2 in {"", "stream_err", "timeout"} or reason2.startswith("error:")
+    assert calls["sync"] == 2
+    assert calls["stream"] == 1
+
+    path_mode, path_reason = llm_module._current_llm_path()
+    assert path_mode == "segment_blocking"
+    assert path_reason in {"stream_err", "timeout"}

--- a/tests/test_metadata_first_queries.py
+++ b/tests/test_metadata_first_queries.py
@@ -1,0 +1,29 @@
+import pipeline_core.llm_service as llm_module
+from pipeline_core.llm_service import LLMMetadataGeneratorService
+
+
+def test_metadata_first_queries(monkeypatch):
+    monkeypatch.setenv("PIPELINE_FAST_TESTS", "1")
+    monkeypatch.setenv("PIPELINE_DISABLE_DYNAMIC_SEGMENT_LLM", "1")
+    llm_module._reset_stream_state_for_tests()
+
+    def fail_segment_json(*_args, **_kwargs):
+        raise AssertionError("segment LLM should not be called in metadata-first mode")
+
+    monkeypatch.setattr(LLMMetadataGeneratorService, "_segment_llm_json", fail_segment_json)
+
+    service = LLMMetadataGeneratorService(reuse_shared=False)
+    service.last_metadata = {
+        "queries": ["Focus Session", "focus sessions", "deep work office"],
+        "broll_keywords": ["people working", "worker", "workers"],
+    }
+    service._metadata_cache_queries = ["Focus Session", "focus sessions", "deep work office"]
+    service._metadata_cache_keywords = ["people working", "worker", "workers"]
+
+    result = service.generate_hints_for_segment("This focus session boosts deep work", 0.0, 5.0)
+
+    assert result["source"] == "metadata_first"
+    assert result["queries"]
+    assert len(result["queries"]) <= 3
+    lowered = {" ".join(q.split()).lower() for q in result["queries"]}
+    assert len(lowered) == len(result["queries"])


### PR DESCRIPTION
## Summary
- respect Settings-derived timeouts/predict caps and persist streaming fallback to blocking after SSE errors
- add a metadata-first segment query path with TF-IDF selection and structured llm_path logging
- update run_pipeline defaults, documentation, and add focused tests for new modes

## Testing
- pytest tests/test_llm_segment_blocking.py tests/test_metadata_first_queries.py tests/test_llm_stream_fallback_once.py

------
https://chatgpt.com/codex/tasks/task_e_68e4bb0e591c833098401020a043e0ab