### PR TITLE
feat: enforce Montserrat subtitles rendering

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
+import os
 import sys
 import types
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
@@ -11,8 +13,6 @@ if str(ROOT_DIR) not in sys.path:
 SRC_DIR = ROOT_DIR / "src"
 if SRC_DIR.exists() and str(SRC_DIR) not in sys.path:
     sys.path.insert(1, str(SRC_DIR))
-
-import os
 
 
 def _install_cv2_stub() -> None:
@@ -238,5 +238,20 @@ _install_moviepy_stub()
 
 os.environ.setdefault("PIPELINE_FAST_TESTS", "1")
 os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+
+
+@pytest.fixture
+def reset_settings_cache():
+    from video_pipeline.config import settings as settings_module
+
+    with settings_module._CACHE_LOCK:  # type: ignore[attr-defined]
+        settings_module._SETTINGS_CACHE = None  # type: ignore[attr-defined]
+    settings_module.reset_startup_log_for_tests()
+    try:
+        yield
+    finally:
+        with settings_module._CACHE_LOCK:  # type: ignore[attr-defined]
+            settings_module._SETTINGS_CACHE = None  # type: ignore[attr-defined]
+        settings_module.reset_startup_log_for_tests()
 
 

--- a/tests/test_subtitles_fit_and_stroke.py
+++ b/tests/test_subtitles_fit_and_stroke.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from hormozi_subtitles import HormoziSubtitles
+from video_pipeline.config.settings import load_settings
+
+
+def _generate_long_words():
+    return [
+        {
+            "animation_progress": 1.0,
+            "tokens": [
+                {"text": word, "color": "#FF6B00", "is_keyword": True if idx % 2 == 0 else False}
+                for idx, word in enumerate(
+                    [
+                        "ULTRA",
+                        "GROWTH",
+                        "STRATEGY",
+                        "DOMINATION",
+                        "PLAYBOOK",
+                        "FORMULA",
+                    ]
+                )
+            ],
+            "emojis": [],
+        }
+    ]
+
+
+@pytest.mark.usefixtures("reset_settings_cache")
+def test_subtitles_fit_and_stroke(monkeypatch):
+    font_path = Path("assets/fonts/Montserrat-ExtraBold.ttf").resolve()
+    monkeypatch.setenv("PIPELINE_SUBTITLE_FONT_PATH", str(font_path))
+
+    settings = load_settings()
+    settings.subtitles.font_size = 140
+    settings.subtitles.keyword_background = False
+
+    subtitles = HormoziSubtitles(subtitle_settings=settings.subtitles)
+
+    width = 1280
+    height = 720
+    frame = np.zeros((height, width, 3), dtype=np.uint8)
+    words = _generate_long_words()
+
+    output = subtitles.create_subtitle_frame(frame.copy(), words, current_time=0.0)
+
+    nonzero = np.argwhere(output.sum(axis=2) > 0)
+    assert nonzero.size > 0
+    min_x = int(nonzero[:, 1].min())
+    max_x = int(nonzero[:, 1].max())
+    rendered_width = max_x - min_x + 1
+
+    stroke_px = subtitles.config.get("stroke_px", 0)
+    shadow_offset = subtitles.config.get("shadow_offset", 0)
+    max_allowed = int(width * 0.92) + 2 * int(stroke_px) + int(shadow_offset)
+
+    assert rendered_width <= max_allowed
+    assert subtitles._last_render_metadata.get("stroke_px") == stroke_px
+
+    dark_pixels = (
+        (output[:, :, 0] < 25)
+        & (output[:, :, 1] < 25)
+        & (output[:, :, 2] < 25)
+    ).sum()
+    assert dark_pixels > 0

--- a/tests/test_subtitles_font_resolution.py
+++ b/tests/test_subtitles_font_resolution.py
@@ -1,0 +1,29 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from hormozi_subtitles import HormoziSubtitles
+from video_pipeline.config.settings import load_settings
+
+
+@pytest.mark.usefixtures("reset_settings_cache")
+def test_font_resolution_prefers_montserrat(monkeypatch, caplog):
+    font_path = Path("assets/fonts/Montserrat-ExtraBold.ttf").resolve()
+    monkeypatch.setenv("PIPELINE_SUBTITLE_FONT_PATH", str(font_path))
+
+    settings = load_settings()
+
+    with caplog.at_level(logging.INFO):
+        subtitles = HormoziSubtitles(subtitle_settings=settings.subtitles)
+
+    using_logs = [msg for msg in caplog.messages if "[Subtitles] Using font:" in msg]
+    assert len(using_logs) == 1
+    assert "montserrat" in using_logs[0].lower()
+
+    joined = " ".join(caplog.messages).lower()
+    assert "impact" not in joined
+
+    resolved_path = subtitles.get_font_path()
+    assert resolved_path is not None
+    assert "montserrat" in Path(resolved_path).name.lower()

--- a/tests/test_subtitles_no_rectangles_when_bg_false.py
+++ b/tests/test_subtitles_no_rectangles_when_bg_false.py
@@ -1,0 +1,47 @@
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from hormozi_subtitles import HormoziSubtitles
+from video_pipeline.config.settings import load_settings
+
+
+def _build_words():
+    return [
+        {
+            "animation_progress": 1.0,
+            "tokens": [
+                {"text": "GROWTH", "color": "#FFAA00", "is_keyword": True},
+                {"text": "BOOST", "color": "#FFFFFF", "is_keyword": False},
+            ],
+            "emojis": [],
+        }
+    ]
+
+
+@pytest.mark.usefixtures("reset_settings_cache")
+def test_no_rectangles_when_keyword_background_disabled(monkeypatch):
+    monkeypatch.setenv("PIPELINE_SUBTITLE_KEYWORD_BACKGROUND", "0")
+    settings = load_settings()
+    settings.subtitles.keyword_background = False
+
+    subtitles = HormoziSubtitles(subtitle_settings=settings.subtitles)
+
+    frame = np.zeros((720, 1280, 3), dtype=np.uint8)
+    words = _build_words()
+
+    with patch("PIL.ImageDraw.ImageDraw.rounded_rectangle") as mock_rect:
+        subtitles.create_subtitle_frame(frame, words, current_time=0.0)
+
+    assert mock_rect.call_count == 0
+
+    keyword_items = [
+        item
+        for item in subtitles._last_render_metadata.get("items", [])
+        if item.get("type") == "word" and item.get("keyword")
+    ]
+    assert keyword_items, "Expected at least one keyword word item"
+    for item in keyword_items:
+        assert item.get("bg_rgb") is None
+        assert item.get("rgb") == subtitles.hex_to_rgb("#FFAA00")

--- a/video_pipeline/config/settings.py
+++ b/video_pipeline/config/settings.py
@@ -473,14 +473,25 @@ def _subtitle_settings(env: Optional[Mapping[str, str]]) -> SubtitleSettings:
             assets_dir / "Montserrat-Bold.ttf",
         ]
     )
+
+    windir = os.getenv("WINDIR")
+    windows_fonts: List[Path] = []
+    if windir:
+        base_fonts = Path(windir) / "Fonts"
+        windows_fonts.extend(
+            [
+                base_fonts / "Montserrat-ExtraBold.ttf",
+                base_fonts / "Montserrat-Bold.ttf",
+            ]
+        )
+
     candidate_paths.extend(
         [
             Path("/System/Library/Fonts/Montserrat-ExtraBold.ttf"),
             Path("/System/Library/Fonts/Montserrat-Bold.ttf"),
             Path("/Library/Fonts/Montserrat-ExtraBold.ttf"),
             Path("/Library/Fonts/Montserrat-Bold.ttf"),
-            Path("C:/Windows/Fonts/Montserrat-ExtraBold.ttf"),
-            Path("C:/Windows/Fonts/Montserrat-Bold.ttf"),
+            *windows_fonts,
         ]
     )
 


### PR DESCRIPTION
## Summary
- prioritize Montserrat font resolution using environment overrides and expand Windows lookup paths
- restrict Impact to a last-resort fallback and keep keyword-only fills without rectangles when backgrounds are disabled
- add a reusable settings cache reset fixture plus targeted tests for font logging, rectangle suppression, and stroke/fit behavior

## Testing
- python -c "from video_pipeline.config.settings import load_settings,log_effective_settings,reset_startup_log_for_tests; reset_startup_log_for_tests(); s=load_settings(); log_effective_settings(s)"
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q --capture=sys tests/test_subtitles_font_resolution.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q --capture=sys tests/test_subtitles_no_rectangles_when_bg_false.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q --capture=sys tests/test_subtitles_fit_and_stroke.py

------
https://chatgpt.com/codex/tasks/task_e_68e51ab5e9288330a4b056c8a2054781