### PR TITLE
chore: normalize fetchers and expose CLI LLM overrides

### DIFF
--- a/docs/HORMOZI_STYLE_AUDIT.md
+++ b/docs/HORMOZI_STYLE_AUDIT.md
@@ -30,6 +30,7 @@ célèbre sur TikTok, et si la logique d'emojis est cohérente.
 * **Police Montserrat ExtraBold forcée** – la résolution de police préfère les
   fichiers Montserrat embarqués ; le chemin retenu est journalisé via `Settings` et
   un log `[Subtitles]` est émis à la première utilisation.【F:video_pipeline/config/settings.py†L170-L229】【F:hormozi_subtitles.py†L251-L308】
+* **Contour et ombre standardisés** – `SubtitleSettings` fixe `stroke_px=6`, `shadow_opacity=0.35` et `shadow_offset=3` pour stabiliser le rendu ; des overrides d'environnement permettent de les modifier sans toucher au code si un preset différent est requis.【F:video_pipeline/config/settings.py†L560-L598】【F:hormozi_subtitles.py†L930-L1038】
 * **Auto-layout stabilisé** – la largeur est rescannée pour rester sous 92 % de la
   vidéo et l'animation conserve un Y lissé pour éviter les sauts, même avec le
   rebond.【F:hormozi_subtitles.py†L820-L912】
@@ -66,6 +67,7 @@ célèbre sur TikTok, et si la logique d'emojis est cohérente.
 * **Placement attaché au mot** – les emojis se superposent désormais dans l'angle
   supérieur droit du groupe coloré, plutôt qu'en suffixe flottant, ce qui renforce la
   lecture verticale sans casser le centrage.【F:hormozi_subtitles.py†L930-L1038】
+* **Fallback neutre optionnel** – `SubtitleSettings.emoji_no_context_fallback` autorise un pictogramme de repli (ex. ⭐) lorsque la sélection automatique ne trouve rien, tout en conservant la densité cible via `emoji_target_per_10`, `emoji_min_gap_groups` et `emoji_max_per_segment`.【F:video_pipeline/config/settings.py†L560-L598】【F:hormozi_subtitles.py†L866-L955】
 
 > **Conclusion** : la narration emoji gagne en cohérence (pas de 💼 hors sujet), en
 > rythme et en densité, tout en restant maîtrisée grâce au seuil cible paramétrable.
@@ -94,3 +96,4 @@ rendraient les emojis plus cohérents avec le contenu des sous-titres.
 * **Config typée appliquée au burn-in** – `video_processor_clean` transmet désormais `get_settings().subtitles` au wrapper `add_hormozi_subtitles`, garantissant que marge, taille, fonds de mots-clés et émojis suivent la configuration centralisée.【F:video_processor_clean.py†L811-L818】
 * **Palette stabilisée + remplissage texte** – `self.category_colors` couvre explicitement `finance`, `sales`, `content`, `mobile`, `sports` et synonymes, avec application directe sur la lettre et stroke configurable.【F:hormozi_subtitles.py†L166-L254】【F:tests/test_subtitles_montserrat_fill.py†L9-L37】
 * **Mapping emoji cohérent** – `category_emojis` fournit une liste pour chaque catégorie, les alias héritent de la même base et la planification applique l'anti-repeat fenêtre de 4 groupes ou retourne `""` en l'absence de contexte.【F:hormozi_subtitles.py†L866-L950】【F:tests/test_emojis_density_and_mapping.py†L18-L53】
+* **Multi-provider LLM** – `LLMSettings` expose désormais le champ `provider` et les overrides CLI (`--llm-provider`, `--llm-model-text`, `--llm-model-json`) mettent à jour la configuration typée ainsi que les variables d'environnement avant l'exécution, tout en ne loguant `[CONFIG]` qu'une seule fois par process.【F:video_pipeline/config/settings.py†L84-L227】【F:run_pipeline.py†L365-L419】【F:video_processor.py†L6678-L6705】

--- a/tests/test_fetchers_normalize_and_pixabay_limits.py
+++ b/tests/test_fetchers_normalize_and_pixabay_limits.py
@@ -1,0 +1,79 @@
+import pytest
+
+from pipeline_core.configuration import FetcherOrchestratorConfig, ProviderConfig
+from pipeline_core.fetchers import FetcherOrchestrator
+
+
+@pytest.mark.parametrize(
+    "keywords",
+    [
+        ["  Hello   world  ", "HELLO WORLD", "hello world"],
+        ["FOCUS   mode", "focus mode", "focus   mode  "],
+    ],
+)
+def test_fetch_candidates_normalize_and_deduplicate(monkeypatch, keywords):
+    provider = ProviderConfig(name="pixabay", enabled=True, max_results=6, supports_videos=True)
+    config = FetcherOrchestratorConfig(
+        providers=(provider,),
+        allow_videos=True,
+        allow_images=False,
+        per_segment_limit=6,
+    )
+    orchestrator = FetcherOrchestrator(config)
+
+    monkeypatch.setenv("PIXABAY_API_KEY", "token")
+
+    calls = []
+
+    def _fake_pixabay_search(api_key, query, *, per_page=50):
+        calls.append({"api_key": api_key, "query": query, "per_page": per_page})
+        return []
+
+    monkeypatch.setattr("pipeline_core.fetchers.pixabay_search_videos", _fake_pixabay_search)
+    monkeypatch.setattr("pipeline_core.fetchers._pixabay_best_video_url", lambda payload: None)
+
+    orchestrator.fetch_candidates(keywords, filters=None)
+
+    assert calls, "expected a provider call"
+    assert len(calls) == 1
+    assert calls[0]["query"] == " ".join(keywords[0].split())
+
+
+def test_pixabay_per_page_limits(monkeypatch):
+    monkeypatch.setenv("PIXABAY_API_KEY", "token")
+
+    calls = []
+
+    def _fake_pixabay_search(api_key, query, *, per_page=50):
+        calls.append({"query": query, "per_page": per_page})
+        return []
+
+    monkeypatch.setattr("pipeline_core.fetchers.pixabay_search_videos", _fake_pixabay_search)
+    monkeypatch.setattr("pipeline_core.fetchers._pixabay_best_video_url", lambda payload: None)
+
+    high_provider = ProviderConfig(name="pixabay", enabled=True, max_results=300)
+    high_config = FetcherOrchestratorConfig(
+        providers=(high_provider,),
+        allow_videos=True,
+        allow_images=False,
+        per_segment_limit=12,
+    )
+    high_orchestrator = FetcherOrchestrator(high_config)
+    high_orchestrator.fetch_candidates(["wide limit"], filters=None)
+
+    assert calls[0]["per_page"] == 200
+
+    calls.clear()
+
+    small_provider = ProviderConfig(name="pixabay", enabled=True, max_results=1)
+    small_config = FetcherOrchestratorConfig(
+        providers=(small_provider,),
+        allow_videos=True,
+        allow_images=False,
+        per_segment_limit=1,
+    )
+    small_orchestrator = FetcherOrchestrator(small_config)
+    small_orchestrator.fetch_candidates(["tight limit"], filters=None)
+
+    assert calls[0]["per_page"] == 50
+    assert calls[0]["query"] == "tight limit"

--- a/video_pipeline/config/__init__.py
+++ b/video_pipeline/config/__init__.py
@@ -9,6 +9,7 @@ from .settings import (
     load_settings,
     get_settings,
     set_settings,
+    apply_llm_overrides,
     log_effective_settings,
     reset_startup_log_for_tests,
 )
@@ -22,6 +23,7 @@ __all__ = [
     "load_settings",
     "get_settings",
     "set_settings",
+    "apply_llm_overrides",
     "log_effective_settings",
     "reset_startup_log_for_tests",
 ]


### PR DESCRIPTION
## Summary
- normalize provider queries, clamp Pixabay pagination, and keep B-roll fallback logging intact
- expose the LLM provider/models through CLI overrides, propagate settings, and keep the config dump single-shot
- document the Montserrat/stroke defaults, emoji density knobs, and the multi-provider LLM flow
- add targeted coverage for query normalization and Pixabay per_page guardrails

## Testing
- pytest -q --capture=sys tests/test_fetchers_normalize_and_pixabay_limits.py

------
https://chatgpt.com/codex/tasks/task_e_68e51b07c3e4833095f6a18e55d0e68b